### PR TITLE
Refactor/dtos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 
 	implementation platform('software.amazon.awssdk:bom:2.20.56')
 

--- a/src/main/java/com/jung/planet/admin/dto/response/AdminResponseDTO.java
+++ b/src/main/java/com/jung/planet/admin/dto/response/AdminResponseDTO.java
@@ -1,0 +1,20 @@
+package com.jung.planet.admin.dto.response;
+
+import com.jung.planet.admin.dto.PremiumUserDTO;
+import com.jung.planet.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AdminResponseDTO {
+    private User user;
+    private String message;
+    private List<PremiumUserDTO> premiumUsers;
+} 

--- a/src/main/java/com/jung/planet/common/dto/ApiResponseDTO.java
+++ b/src/main/java/com/jung/planet/common/dto/ApiResponseDTO.java
@@ -1,0 +1,66 @@
+package com.jung.planet.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ApiResponseDTO<T> {
+    private boolean success;
+    private T data;
+    private String message;
+    private Map<String, String> errors;
+
+    public static <T> ApiResponseDTO<T> success(T data) {
+        return ApiResponseDTO.<T>builder()
+                .success(true)
+                .data(data)
+                .message("요청이 성공적으로 처리되었습니다.")
+                .build();
+    }
+
+    public static <T> ApiResponseDTO<T> success(T data, String message) {
+        return ApiResponseDTO.<T>builder()
+                .success(true)
+                .data(data)
+                .message(message)
+                .build();
+    }
+
+    public static ApiResponseDTO<Void> success(String message) {
+        return ApiResponseDTO.<Void>builder()
+                .success(true)
+                .message(message)
+                .build();
+    }
+
+    public static ApiResponseDTO<Void> error(String message) {
+        return ApiResponseDTO.<Void>builder()
+                .success(false)
+                .message(message)
+
+                .build();
+    }
+    
+    public static <T> ApiResponseDTO<T> error(String message, T errors) {
+        return ApiResponseDTO.<T>builder()
+                .success(false)
+                .message(message)
+                .data(errors)
+                .build();
+    }
+    
+    public static ApiResponseDTO<Void> error(String message, Map<String, String> errors) {
+        return ApiResponseDTO.<Void>builder()
+                .success(false)
+                .message(message)
+                .errors(errors)
+                .build();
+    }
+}

--- a/src/main/java/com/jung/planet/diary/controller/DiaryController.java
+++ b/src/main/java/com/jung/planet/diary/controller/DiaryController.java
@@ -1,7 +1,9 @@
 package com.jung.planet.diary.controller;
 
+import com.jung.planet.common.dto.ApiResponseDTO;
 import com.jung.planet.diary.dto.DiaryDetailDTO;
 import com.jung.planet.diary.dto.request.DiaryFormDTO;
+import com.jung.planet.diary.dto.response.DiaryResponseDTO;
 import com.jung.planet.diary.entity.Diary;
 import com.jung.planet.diary.service.DiaryService;
 import com.jung.planet.plant.controller.PlantController;
@@ -16,11 +18,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.Map;
 
 @Tag(name = "Diary", description = "다이어리 관련 API")
 @RestController
@@ -40,11 +39,11 @@ public class DiaryController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @GetMapping("/{id}")
-    public ResponseEntity<DiaryDetailDTO> findDiary(
+    public ApiResponseDTO<DiaryDetailDTO> findDiary(
         @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @Parameter(description = "다이어리 ID") @PathVariable("id") Long diaryId) {
         DiaryDetailDTO diary = diaryService.findDiary(diaryId, customUserDetails.getUserId());
-        return ResponseEntity.ok(diary);
+        return ApiResponseDTO.success(diary);
     }
 
     @Operation(summary = "다이어리 작성", description = "새로운 다이어리를 작성합니다.")
@@ -55,14 +54,19 @@ public class DiaryController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @PostMapping("/add")
-    public ResponseEntity<Map<String, Object>> addDiary(
+    public ApiResponseDTO<DiaryResponseDTO> addDiary(
         @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @RequestBody DiaryFormDTO diaryFormDTO) {
         logger.info("Request to add diary: {}", diaryFormDTO.toString());
         Diary diary = diaryService.addDiary(customUserDetails.getUsername(), diaryFormDTO);
         logger.info("Diary added: {}", diary);
 
-        return ResponseEntity.ok(Map.of("ok", true));
+        DiaryResponseDTO responseDTO = DiaryResponseDTO.builder()
+                .diaryId(diary.getId())
+                .success(true)
+                .build();
+
+        return ApiResponseDTO.success(responseDTO, "다이어리가 성공적으로 추가되었습니다.");
     }
 
     @Operation(summary = "다이어리 수정", description = "기존 다이어리를 수정합니다.")
@@ -74,12 +78,18 @@ public class DiaryController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @PostMapping("/edit/{id}")
-    public ResponseEntity<?> editDiary(
+    public ApiResponseDTO<DiaryResponseDTO> editDiary(
         @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @Parameter(description = "다이어리 ID") @PathVariable("id") Long diaryId,
         @RequestBody DiaryFormDTO diaryEditDTO) {
         diaryService.editDiary(customUserDetails, diaryId, diaryEditDTO);
-        return ResponseEntity.ok(Map.of("ok", true));
+        
+        DiaryResponseDTO responseDTO = DiaryResponseDTO.builder()
+                .diaryId(diaryId)
+                .success(true)
+                .build();
+                
+        return ApiResponseDTO.success(responseDTO, "다이어리가 성공적으로 수정되었습니다.");
     }
 
     @Operation(summary = "다이어리 삭제", description = "기존 다이어리를 삭제합니다.")
@@ -91,10 +101,16 @@ public class DiaryController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @DeleteMapping("/remove/{id}")
-    public ResponseEntity<?> removeDiary(
+    public ApiResponseDTO<DiaryResponseDTO> removeDiary(
         @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @Parameter(description = "다이어리 ID") @PathVariable("id") Long diaryId) {
         diaryService.deleteDiary(diaryId, customUserDetails);
-        return ResponseEntity.ok(Map.of("ok", true));
+        
+        DiaryResponseDTO responseDTO = DiaryResponseDTO.builder()
+                .diaryId(diaryId)
+                .success(true)
+                .build();
+                
+        return ApiResponseDTO.success(responseDTO, "다이어리가 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/jung/planet/diary/dto/response/DiaryResponseDTO.java
+++ b/src/main/java/com/jung/planet/diary/dto/response/DiaryResponseDTO.java
@@ -1,0 +1,15 @@
+package com.jung.planet.diary.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DiaryResponseDTO {
+    private Long diaryId;
+    private boolean success;
+} 

--- a/src/main/java/com/jung/planet/plant/controller/UserPlantHeartController.java
+++ b/src/main/java/com/jung/planet/plant/controller/UserPlantHeartController.java
@@ -1,17 +1,15 @@
 package com.jung.planet.plant.controller;
 
-
+import com.jung.planet.common.dto.ApiResponseDTO;
+import com.jung.planet.plant.dto.response.HeartResponseDTO;
 import com.jung.planet.plant.service.UserPlantHeartService;
 import com.jung.planet.security.UserDetail.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Map;
 
 @RestController
 @RequestMapping("/plants")
@@ -20,10 +18,15 @@ public class UserPlantHeartController {
 
     private final UserPlantHeartService userPlantHeartService;
 
-
     @PostMapping("/heart/{id}")
-    public ResponseEntity<?> togglePlantHeart(@AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable("id") Long plantId) {
+    public ApiResponseDTO<HeartResponseDTO> togglePlantHeart(@AuthenticationPrincipal CustomUserDetails customUserDetails, @PathVariable("id") Long plantId) {
         boolean hearted = userPlantHeartService.togglePlantHeart(customUserDetails.getUserId(), plantId);
-        return ResponseEntity.ok(Map.of("hearted", hearted));
+        
+        HeartResponseDTO responseDTO = HeartResponseDTO.builder()
+                .plantId(plantId)
+                .hearted(hearted)
+                .build();
+                
+        return ApiResponseDTO.success(responseDTO, hearted ? "식물에 좋아요를 표시했습니다." : "식물에 좋아요를 취소했습니다.");
     }
 }

--- a/src/main/java/com/jung/planet/plant/dto/response/HeartResponseDTO.java
+++ b/src/main/java/com/jung/planet/plant/dto/response/HeartResponseDTO.java
@@ -1,0 +1,15 @@
+package com.jung.planet.plant.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class HeartResponseDTO {
+    private Long plantId;
+    private boolean hearted;
+} 

--- a/src/main/java/com/jung/planet/plant/dto/response/PlantResponseDTO.java
+++ b/src/main/java/com/jung/planet/plant/dto/response/PlantResponseDTO.java
@@ -1,0 +1,35 @@
+package com.jung.planet.plant.dto.response;
+
+import com.jung.planet.plant.dto.PlantSummaryDTO;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlantResponseDTO {
+    private Long plantId;
+    private boolean success;
+    private List<PlantSummaryDTO> plants;
+    
+    // 단일 식물 응답을 위한 팩토리 메서드
+    public static PlantResponseDTO forSinglePlant(Long plantId) {
+        return PlantResponseDTO.builder()
+                .plantId(plantId)
+                .success(true)
+                .build();
+    }
+    
+    // 식물 목록 응답을 위한 팩토리 메서드
+    public static PlantResponseDTO forPlantList(List<PlantSummaryDTO> plants) {
+        return PlantResponseDTO.builder()
+                .plants(plants)
+                .success(true)
+                .build();
+    }
+} 

--- a/src/main/java/com/jung/planet/report/controller/ReportController.java
+++ b/src/main/java/com/jung/planet/report/controller/ReportController.java
@@ -1,6 +1,8 @@
 package com.jung.planet.report.controller;
 
+import com.jung.planet.common.dto.ApiResponseDTO;
 import com.jung.planet.report.dto.ReportDTO;
+import com.jung.planet.report.dto.ReportResponseDTO;
 import com.jung.planet.report.entity.ReportType;
 import com.jung.planet.report.service.ReportService;
 import com.jung.planet.security.UserDetail.CustomUserDetails;
@@ -12,12 +14,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @Tag(name = "Report", description = "신고 관련 API")
 @RestController
@@ -34,11 +34,11 @@ public class ReportController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @PostMapping("/plant/{plantId}")
-    public ResponseEntity<?> reportPlant(
+    public ApiResponseDTO<Void> reportPlant(
         @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @Parameter(description = "식물 ID") @PathVariable Long plantId) {
         reportService.reportEntity(plantId, ReportType.PLANT, customUserDetails.getUserId());
-        return ResponseEntity.ok("Plant reported successfully");
+        return ApiResponseDTO.success("식물이 성공적으로 신고되었습니다.");
     }
 
     @Operation(summary = "다이어리 신고", description = "특정 다이어리를 신고합니다.")
@@ -49,11 +49,11 @@ public class ReportController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @PostMapping("/diary/{diaryId}")
-    public ResponseEntity<?> reportDiary(
+    public ApiResponseDTO<Void> reportDiary(
         @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @Parameter(description = "다이어리 ID") @PathVariable Long diaryId) {
         reportService.reportEntity(diaryId, ReportType.DIARY, customUserDetails.getUserId());
-        return ResponseEntity.ok("Diary reported successfully");
+        return ApiResponseDTO.success("다이어리가 성공적으로 신고되었습니다.");
     }
 
     @Operation(summary = "신고 목록 조회", description = "신고된 식물 또는 다이어리 목록을 조회합니다.")
@@ -64,16 +64,20 @@ public class ReportController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @GetMapping
-    public ResponseEntity<?> reportedDiary(
+    public ApiResponseDTO<ReportResponseDTO> reportedDiary(
         @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @Parameter(description = "신고 유형 (plant/diary)") @RequestParam String type) {
+        ReportResponseDTO responseDTO = ReportResponseDTO.builder().build();
+        
         if (type.equals("plant")) {
             List<ReportDTO> allPlantReports = reportService.getAllPlantReports();
-            return ResponseEntity.ok(Map.of("reportedPlants", allPlantReports));
+            responseDTO.setReportedPlants(allPlantReports);
         } else {
             List<ReportDTO> allDiaryReports = reportService.getAllDiaryReports();
-            return ResponseEntity.ok(Map.of("reportedDiaries", allDiaryReports));
+            responseDTO.setReportedDiaries(allDiaryReports);
         }
+        
+        return ApiResponseDTO.success(responseDTO);
     }
 }
 

--- a/src/main/java/com/jung/planet/report/dto/ReportResponseDTO.java
+++ b/src/main/java/com/jung/planet/report/dto/ReportResponseDTO.java
@@ -1,0 +1,17 @@
+package com.jung.planet.report.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReportResponseDTO {
+    private List<ReportDTO> reportedPlants;
+    private List<ReportDTO> reportedDiaries;
+} 

--- a/src/main/java/com/jung/planet/user/controller/UserController.java
+++ b/src/main/java/com/jung/planet/user/controller/UserController.java
@@ -1,11 +1,14 @@
 package com.jung.planet.user.controller;
 
+import com.jung.planet.common.dto.ApiResponseDTO;
 import com.jung.planet.plant.repository.UserPlantHeartRepository;
 import com.jung.planet.plant.service.PlantService;
 import com.jung.planet.security.JwtTokenProvider;
 import com.jung.planet.security.UserDetail.CustomUserDetails;
 import com.jung.planet.user.dto.JwtResponse;
 import com.jung.planet.user.dto.UserDTO;
+import com.jung.planet.user.dto.response.TokenResponseDTO;
+import com.jung.planet.user.dto.response.UserResponseDTO;
 import com.jung.planet.user.entity.User;
 import com.jung.planet.user.repository.UserRepository;
 import com.jung.planet.user.service.UserService;
@@ -22,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -54,12 +56,13 @@ public class UserController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @PostMapping("/login")
-    public ResponseEntity<?> getCurrentUser(@RequestBody UserDTO userDTO) {
+    public ApiResponseDTO<JwtResponse> getCurrentUser(@RequestBody UserDTO userDTO) {
         logger.debug("USER LOGIN :: {} ", userDTO);
         User user = userService.processUser(userDTO);
         String access_token = jwtTokenProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole());
 
-        return ResponseEntity.ok(new JwtResponse(access_token, user.getRefreshToken(), user));
+        JwtResponse response = new JwtResponse(access_token, user.getRefreshToken(), user);
+        return ApiResponseDTO.success(response, "로그인이 성공적으로 완료되었습니다.");
     }
 
     @Operation(summary = "회원 탈퇴", description = "현재 로그인한 사용자의 계정을 삭제합니다.")
@@ -69,9 +72,9 @@ public class UserController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @DeleteMapping("/remove")
-    public ResponseEntity<?> deleteUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public ApiResponseDTO<Void> deleteUser(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         userService.deleteUser(customUserDetails);
-        return ResponseEntity.ok(Map.of("ok", true));
+        return ApiResponseDTO.success("사용자 계정이 성공적으로 삭제되었습니다.");
     }
 
     @Operation(summary = "토큰 갱신", description = "리프레시 토큰을 사용하여 새로운 액세스 토큰을 발급받습니다.")
@@ -81,7 +84,7 @@ public class UserController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @PostMapping("/refresh")
-    public ResponseEntity<?> refreshTokens(@RequestParam String refreshToken) {
+    public ApiResponseDTO<TokenResponseDTO> refreshTokens(@RequestParam String refreshToken) {
         String email = jwtTokenProvider.decodeJwt(refreshToken).getSubject();
         Optional<User> user = userService.findByEmail(email);
 
@@ -91,12 +94,14 @@ public class UserController {
 
             userService.updateRefreshToken(user.get().getId(), newRefreshToken);
 
-            Map<String, String> tokens = new HashMap<>();
-            tokens.put("access_token", newAccessToken);
-            tokens.put("refresh_token", newRefreshToken);
-            return ResponseEntity.ok(tokens);
+            TokenResponseDTO tokenResponse = TokenResponseDTO.builder()
+                    .access_token(newAccessToken)
+                    .refresh_token(newRefreshToken)
+                    .build();
+                    
+            return ApiResponseDTO.success(tokenResponse, "토큰이 성공적으로 갱신되었습니다.");
         } else {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).body("Invalid Refresh Token");
+            return ApiResponseDTO.error("유효하지 않은 리프레시 토큰입니다.", TokenResponseDTO.builder().build());
         }
     }
 
@@ -108,7 +113,7 @@ public class UserController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
     @GetMapping("/my-info")
-    public ResponseEntity<?> getMyInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
+    public ApiResponseDTO<UserResponseDTO> getMyInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long userId = customUserDetails.getUserId();
         User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException("해당하는 유저를 찾을 수 없습니다."));
 
@@ -118,15 +123,15 @@ public class UserController {
         int maxPlants = user.getSubscription().getMaxPlants();
         boolean aiServiceAccess = user.getSubscription().isAiServiceAccess();
 
-        Map<String, Object> userInfo = Map.of(
-                "name", user.getName(),
-                "period", daysSinceCreated,
-                "receivedHearts", totalHearts,
-                "givenHearts", totalHeartsGivenByUser,
-                "maxPlants", maxPlants,
-                "aiServiceAccess", aiServiceAccess
-        );
+        UserResponseDTO userResponse = UserResponseDTO.builder()
+                .name(user.getName())
+                .period(daysSinceCreated)
+                .receivedHearts(totalHearts)
+                .givenHearts(totalHeartsGivenByUser)
+                .maxPlants(maxPlants)
+                .aiServiceAccess(aiServiceAccess)
+                .build();
 
-        return ResponseEntity.ok(userInfo);
+        return ApiResponseDTO.success(userResponse);
     }
 }

--- a/src/main/java/com/jung/planet/user/dto/response/TokenResponseDTO.java
+++ b/src/main/java/com/jung/planet/user/dto/response/TokenResponseDTO.java
@@ -1,0 +1,15 @@
+package com.jung.planet.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TokenResponseDTO {
+    private String access_token;
+    private String refresh_token;
+} 

--- a/src/main/java/com/jung/planet/user/dto/response/UserResponseDTO.java
+++ b/src/main/java/com/jung/planet/user/dto/response/UserResponseDTO.java
@@ -1,0 +1,32 @@
+package com.jung.planet.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.Map;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UserResponseDTO {
+    private String name;
+    private long period;
+    private int receivedHearts;
+    private int givenHearts;
+    private int maxPlants;
+    private boolean aiServiceAccess;
+    
+    public static UserResponseDTO fromMap(Map<String, Object> map) {
+        return UserResponseDTO.builder()
+                .name((String) map.get("name"))
+                .period((long) map.get("period"))
+                .receivedHearts((int) map.get("receivedHearts"))
+                .givenHearts((int) map.get("givenHearts"))
+                .maxPlants((int) map.get("maxPlants"))
+                .aiServiceAccess((boolean) map.get("aiServiceAccess"))
+                .build();
+    }
+} 

--- a/src/test/java/com/jung/planet/diary/controller/DiaryControllerTest.java
+++ b/src/test/java/com/jung/planet/diary/controller/DiaryControllerTest.java
@@ -1,0 +1,163 @@
+package com.jung.planet.diary.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jung.planet.diary.dto.DiaryDetailDTO;
+import com.jung.planet.diary.dto.request.DiaryFormDTO;
+import com.jung.planet.diary.entity.Diary;
+import com.jung.planet.diary.service.DiaryService;
+import com.jung.planet.plant.entity.Plant;
+import com.jung.planet.security.UserDetail.CustomUserDetails;
+import com.jung.planet.user.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class DiaryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private DiaryService diaryService;
+
+    private CustomUserDetails mockUserDetails;
+    private Diary mockDiary;
+    private DiaryDetailDTO mockDiaryDetail;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 사용자 정보 설정
+        mockUserDetails = new CustomUserDetails(1L, "test@example.com",  UserRole.NORMAL,null);
+        
+        // 테스트용 Plant 객체 생성
+        Plant mockPlant = Plant.builder()
+            .nickName("테스트 식물")
+            .scientificName("테스트 학명")
+            .imgUrl("http://example.com/plant.jpg")
+            .build();
+            
+        // 테스트 다이어리 설정 - builder 패턴 사용
+        mockDiary = Diary.builder()
+            .plant(mockPlant)
+            .content("테스트 내용")
+            .isPublic(true)
+            .imgUrl("http://example.com/image.jpg")
+            .createdAt(LocalDateTime.now())
+            .build();
+            
+        // 테스트용으로 ID 설정을 위한 리플렉션 사용
+        try {
+            java.lang.reflect.Field idField = Diary.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(mockDiary, 1L);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        
+        // 테스트 다이어리 상세 DTO 설정
+        mockDiaryDetail = new DiaryDetailDTO();
+        mockDiaryDetail.setId(1L);
+        mockDiaryDetail.setContent("테스트 내용");
+        mockDiaryDetail.setPublic(true);
+        mockDiaryDetail.setImgUrl("http://example.com/image.jpg");
+        mockDiaryDetail.setCreatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        mockDiaryDetail.setMine(true);
+        
+        // 서비스 메소드 모킹
+        when(diaryService.findDiary(anyLong(), anyLong())).thenReturn(mockDiaryDetail);
+        when(diaryService.addDiary(anyString(), any(DiaryFormDTO.class))).thenReturn(mockDiary);
+        doNothing().when(diaryService).editDiary(any(CustomUserDetails.class), anyLong(), any(DiaryFormDTO.class));
+        doNothing().when(diaryService).deleteDiary(anyLong(), any(CustomUserDetails.class));
+    }
+
+    @Test
+    @DisplayName("다이어리 상세 조회")
+    @WithMockUser
+    void findDiary() throws Exception {
+        mockMvc.perform(get("/diary/1")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.content").value("테스트 내용"))
+            .andExpect(jsonPath("$.data.imgUrl").value("http://example.com/image.jpg"));
+    }
+
+    @Test
+    @DisplayName("다이어리 작성")
+    @WithMockUser
+    void addDiary() throws Exception {
+        DiaryFormDTO diaryFormDTO = new DiaryFormDTO();
+        diaryFormDTO.setPlantId(1L);
+        diaryFormDTO.setContent("새 내용");
+        diaryFormDTO.setImgData("base64EncodedImageData");
+        diaryFormDTO.setIsPublic(true);
+        diaryFormDTO.setCreatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        
+        mockMvc.perform(post("/diary/add")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(diaryFormDTO)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.diaryId").value(1L));
+    }
+
+    @Test
+    @DisplayName("다이어리 수정")
+    @WithMockUser
+    void editDiary() throws Exception {
+        DiaryFormDTO diaryFormDTO = new DiaryFormDTO();
+        diaryFormDTO.setPlantId(1L);
+        diaryFormDTO.setContent("수정된 내용");
+        diaryFormDTO.setImgData("base64EncodedImageData");
+        diaryFormDTO.setIsPublic(true);
+        diaryFormDTO.setCreatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        
+        mockMvc.perform(post("/diary/edit/1")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(diaryFormDTO)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.diaryId").value(1L));
+    }
+
+    @Test
+    @DisplayName("다이어리 삭제")
+    @WithMockUser
+    void removeDiary() throws Exception {
+        mockMvc.perform(delete("/diary/remove/1")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.diaryId").value(1L));
+    }
+} 

--- a/src/test/java/com/jung/planet/plant/controller/PlantControllerTest.java
+++ b/src/test/java/com/jung/planet/plant/controller/PlantControllerTest.java
@@ -1,0 +1,235 @@
+package com.jung.planet.plant.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jung.planet.common.dto.ApiResponseDTO;
+import com.jung.planet.plant.dto.PlantDetailDTO;
+import com.jung.planet.plant.dto.PlantSummaryDTO;
+import com.jung.planet.plant.dto.request.PlantFormDTO;
+import com.jung.planet.plant.entity.Plant;
+import com.jung.planet.plant.service.PlantService;
+import com.jung.planet.security.UserDetail.CustomUserDetails;
+import com.jung.planet.user.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PlantControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private PlantService plantService;
+
+    private CustomUserDetails mockUserDetails;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 사용자 정보 설정
+        mockUserDetails = new CustomUserDetails(1L, "test@example.com", UserRole.NORMAL, null);
+        
+        // 테스트 데이터 설정 - builder 패턴 사용
+        Plant mockPlant = Plant.builder()
+            .nickName("테스트 식물")
+            .scientificName("테스트 학명")
+            .imgUrl("http://example.com/image.jpg")
+            .build();
+        
+        // 테스트용으로 ID 설정을 위한 리플렉션 사용 (실제 엔티티에 setter 없을 때)
+        try {
+            java.lang.reflect.Field idField = Plant.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(mockPlant, 1L);
+            
+            java.lang.reflect.Field createdAtField = Plant.class.getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(mockPlant, LocalDateTime.now());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        
+        // Mock 응답 설정 - setter 사용
+        List<PlantSummaryDTO> mockPlants = new ArrayList<>();
+        
+        PlantSummaryDTO plant1 = new PlantSummaryDTO();
+        plant1.setId(1L);
+        plant1.setNickName("테스트 식물1");
+        plant1.setImgUrl("http://example.com/image1.jpg");
+        plant1.setPeriod(30);
+        plant1.setHeartCount(10);
+        
+        PlantSummaryDTO plant2 = new PlantSummaryDTO();
+        plant2.setId(2L);
+        plant2.setNickName("테스트 식물2");
+        plant2.setImgUrl("http://example.com/image2.jpg");
+        plant2.setPeriod(60);
+        plant2.setHeartCount(20);
+        
+        mockPlants.add(plant1);
+        mockPlants.add(plant2);
+        
+        // PlantDetailDTO도 setter 사용
+        PlantDetailDTO mockPlantDetail = new PlantDetailDTO();
+        mockPlantDetail.setPlantId(1L);
+        mockPlantDetail.setNickName("테스트 식물");
+        mockPlantDetail.setScientificName("테스트 학명");
+        mockPlantDetail.setImgUrl("http://example.com/image.jpg");
+        mockPlantDetail.setHeartCount(5);
+        mockPlantDetail.setPeriod(30);
+        mockPlantDetail.setMine(false);
+        mockPlantDetail.setHearted(false);
+        mockPlantDetail.setCreatedAt(LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
+        mockPlantDetail.setDiaries(Collections.emptyList());
+            
+        // 서비스 메소드 모킹
+        when(plantService.getPlantsByRecent(0)).thenReturn(mockPlants);
+        when(plantService.getPlantsByPopularity(0)).thenReturn(mockPlants);
+        when(plantService.getHeartedPlantsByUser(anyLong(), eq(0))).thenReturn(mockPlants);
+        when(plantService.getPlantDetailsByPlantId(anyLong(), anyLong())).thenReturn(mockPlantDetail);
+        when(plantService.addPlant(any(PlantFormDTO.class))).thenReturn(mockPlant);
+        when(plantService.isOwnerOfPlant(eq(1L), anyLong())).thenReturn(true);
+        when(plantService.editPlant(any(PlantFormDTO.class), anyLong())).thenReturn(mockPlant);
+        when(plantService.getPlantsByUserId(anyLong())).thenReturn(mockPlants);
+        when(plantService.getRandomPlants()).thenReturn(mockPlants);
+    }
+
+    @Test
+    @DisplayName("식물 목록 조회 - 최신순")
+    @WithMockUser
+    void getPlantsRecent() throws Exception {
+        mockMvc.perform(get("/plants")
+                .param("type", "recent")
+                .param("page", "0")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.plants[0].nickName").value("테스트 식물1"))
+            .andExpect(jsonPath("$.data.plants[1].nickName").value("테스트 식물2"));
+    }
+
+    @Test
+    @DisplayName("식물 목록 조회 - 인기순")
+    @WithMockUser
+    void getPlantsPopular() throws Exception {
+        mockMvc.perform(get("/plants")
+                .param("type", "popular")
+                .param("page", "0")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.plants[0].nickName").value("테스트 식물1"));
+    }
+
+    @Test
+    @DisplayName("식물 상세 조회")
+    @WithMockUser
+    void getPlant() throws Exception {
+        mockMvc.perform(get("/plants/1")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.nickName").value("테스트 식물"))
+            .andExpect(jsonPath("$.data.scientificName").value("테스트 학명"));
+    }
+
+    @Test
+    @DisplayName("식물 추가")
+    @WithMockUser
+    void addPlant() throws Exception {
+        PlantFormDTO plantFormDTO = new PlantFormDTO();
+        plantFormDTO.setUserId(1L);
+        plantFormDTO.setNickName("새 식물");
+        plantFormDTO.setScientificName("새 식물 학명");
+        plantFormDTO.setImgData("base64EncodedImageData");
+
+        mockMvc.perform(post("/plants/add")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(plantFormDTO)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.plantId").value(1L));
+    }
+
+    @Test
+    @DisplayName("식물 수정")
+    @WithMockUser
+    void editPlant() throws Exception {
+        PlantFormDTO plantFormDTO = new PlantFormDTO();
+        plantFormDTO.setUserId(1L);
+        plantFormDTO.setNickName("수정된 식물");
+        plantFormDTO.setScientificName("수정된 학명");
+        plantFormDTO.setImgData("base64EncodedImageData");
+
+        mockMvc.perform(post("/plants/edit/1")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(plantFormDTO)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.plantId").value(1L));
+    }
+
+    @Test
+    @DisplayName("내 식물 목록 조회")
+    @WithMockUser
+    void getMyPlants() throws Exception {
+        mockMvc.perform(get("/plants/my")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.plants[0].nickName").value("테스트 식물1"));
+    }
+
+    @Test
+    @DisplayName("랜덤 식물 목록 조회")
+    @WithMockUser
+    void getRandomPlants() throws Exception {
+        mockMvc.perform(get("/plants/random"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.plants[0].nickName").value("테스트 식물1"));
+    }
+
+    @Test
+    @DisplayName("식물 삭제")
+    @WithMockUser
+    void deletePlant() throws Exception {
+        mockMvc.perform(delete("/plants/remove/1")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.plantId").value(1L));
+    }
+} 

--- a/src/test/java/com/jung/planet/plant/controller/UserPlantHeartControllerTest.java
+++ b/src/test/java/com/jung/planet/plant/controller/UserPlantHeartControllerTest.java
@@ -1,0 +1,69 @@
+package com.jung.planet.plant.controller;
+
+import com.jung.planet.plant.service.UserPlantHeartService;
+import com.jung.planet.security.UserDetail.CustomUserDetails;
+import com.jung.planet.user.entity.UserRole;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserPlantHeartControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private UserPlantHeartService userPlantHeartService;
+
+    private CustomUserDetails mockUserDetails;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 사용자 정보 설정
+        mockUserDetails = new CustomUserDetails(1L, "test@example.com", UserRole.NORMAL, null);
+        
+        // 서비스 메소드 모킹
+        when(userPlantHeartService.togglePlantHeart(anyLong(), anyLong())).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("식물 좋아요 토글")
+    @WithMockUser
+    void togglePlantHeart() throws Exception {
+        mockMvc.perform(post("/plants/heart/1")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.plantId").value(1))
+            .andExpect(jsonPath("$.data.hearted").value(true));
+    }
+    
+    @Test
+    @DisplayName("식물 좋아요 취소 토글")
+    @WithMockUser
+    void togglePlantHeartCancel() throws Exception {
+        when(userPlantHeartService.togglePlantHeart(anyLong(), anyLong())).thenReturn(false);
+        
+        mockMvc.perform(post("/plants/heart/1")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.plantId").value(1))
+            .andExpect(jsonPath("$.data.hearted").value(false));
+    }
+} 

--- a/src/test/java/com/jung/planet/user/controller/UserControllerTest.java
+++ b/src/test/java/com/jung/planet/user/controller/UserControllerTest.java
@@ -1,0 +1,168 @@
+package com.jung.planet.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.jung.planet.plant.repository.UserPlantHeartRepository;
+import com.jung.planet.plant.service.PlantService;
+import com.jung.planet.security.JwtTokenProvider;
+import com.jung.planet.security.UserDetail.CustomUserDetails;
+import com.jung.planet.user.dto.JwtResponse;
+import com.jung.planet.user.dto.UserDTO;
+import com.jung.planet.user.entity.Subscription;
+import com.jung.planet.user.entity.SubscriptionType;
+import com.jung.planet.user.entity.User;
+import com.jung.planet.user.entity.UserRole;
+import com.jung.planet.user.repository.UserRepository;
+import com.jung.planet.user.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private PlantService plantService;
+
+    @MockBean
+    private UserPlantHeartRepository userPlantHeartRepository;
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    private CustomUserDetails mockUserDetails;
+    private User mockUser;
+
+    @BeforeEach
+    void setUp() {
+        // 테스트용 사용자 정보 설정
+        mockUserDetails = new CustomUserDetails(1L, "test@example.com", UserRole.NORMAL, null);
+        
+        // 테스트 구독 정보 설정
+        Subscription subscription = new Subscription();
+        subscription.setType(SubscriptionType.BASIC);
+        subscription.setMaxPlants(3);
+        subscription.setAiServiceAccess(false);
+
+        // 테스트 사용자 설정
+        mockUser = User.builder()
+            .email("test@example.com")
+            .name("테스트 사용자")
+            .refreshToken("test-refresh-token")
+            .subscription(subscription)
+            .build();
+            
+        // 테스트용으로 ID 및 생성일 설정을 위한 리플렉션 사용
+        try {
+            java.lang.reflect.Field idField = User.class.getDeclaredField("id");
+            idField.setAccessible(true);
+            idField.set(mockUser, 1L);
+            
+            java.lang.reflect.Field createdAtField = User.class.getDeclaredField("createdAt");
+            createdAtField.setAccessible(true);
+            createdAtField.set(mockUser, LocalDateTime.now().minusDays(30));
+            
+            java.lang.reflect.Field roleField = User.class.getDeclaredField("role");
+            roleField.setAccessible(true);
+            roleField.set(mockUser, UserRole.NORMAL);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        
+        // 서비스 메소드 모킹
+        when(userService.processUser(any(UserDTO.class))).thenReturn(mockUser);
+        when(userService.findByEmail(anyString())).thenReturn(Optional.of(mockUser));
+        when(jwtTokenProvider.createAccessToken(anyLong(), anyString(), any(UserRole.class))).thenReturn("test-access-token");
+        when(jwtTokenProvider.createRefreshToken(anyLong(), anyString(), any(UserRole.class))).thenReturn("new-refresh-token");
+        when(jwtTokenProvider.validateToken(anyString())).thenReturn(true);
+        when(userRepository.findById(anyLong())).thenReturn(Optional.of(mockUser));
+        when(plantService.getTotalHearts(anyLong())).thenReturn(5);
+        when(userPlantHeartRepository.countByUserId(anyLong())).thenReturn(3);
+    }
+
+    @Test
+    @DisplayName("사용자 로그인")
+    void login() throws Exception {
+        UserDTO userDTO = new UserDTO();
+        userDTO.setEmail("test@example.com");
+        userDTO.setName("테스트 사용자");
+        
+        mockMvc.perform(post("/users/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(userDTO)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.access_token").exists())
+            .andExpect(jsonPath("$.data.user.email").value("test@example.com"));
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴")
+    @WithMockUser
+    void deleteUser() throws Exception {
+        mockMvc.perform(delete("/users/remove")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.message").exists());
+    }
+
+    @Test
+    @DisplayName("토큰 갱신")
+    void refreshTokens() throws Exception {
+        mockMvc.perform(post("/users/refresh")
+                .param("refreshToken", "test-refresh-token"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.access_token").value("test-access-token"))
+            .andExpect(jsonPath("$.data.refresh_token").value("new-refresh-token"));
+    }
+
+    @Test
+    @DisplayName("내 정보 조회")
+    @WithMockUser
+    void getMyInfo() throws Exception {
+        mockMvc.perform(get("/users/my-info")
+                .with(SecurityMockMvcRequestPostProcessors.user(mockUserDetails)))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.name").value("테스트 사용자"))
+            .andExpect(jsonPath("$.data.receivedHearts").value(5))
+            .andExpect(jsonPath("$.data.givenHearts").value(3))
+            .andExpect(jsonPath("$.data.maxPlants").value(3))
+            .andExpect(jsonPath("$.data.aiServiceAccess").value(false));
+    }
+} 

--- a/src/test/java/com/jung/planet/user/service/UserServiceTest.java
+++ b/src/test/java/com/jung/planet/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package com.jung.planet.user.service;
 import com.jung.planet.security.JwtTokenProvider;
 import com.jung.planet.user.dto.UserDTO;
 import com.jung.planet.user.entity.User;
+import com.jung.planet.user.entity.UserRole;
 import com.jung.planet.user.repository.UserRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -40,7 +41,7 @@ public class UserServiceTest {
         userDTO.setEmail("newuser@example.com");
 
         when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
-        when(jwtTokenProvider.createRefreshToken(anyLong(), anyString())).thenReturn("mockRefreshToken");
+        when(jwtTokenProvider.createRefreshToken(anyLong(), anyString(), any(UserRole.class))).thenReturn("mockRefreshToken");
 
         // When
         User result = userService.processUser(userDTO);
@@ -61,7 +62,7 @@ public class UserServiceTest {
         userDTO.setName("Existing User");
 
         when(userRepository.findByEmail(anyString())).thenReturn(Optional.of(existingUser));
-        when(jwtTokenProvider.createRefreshToken(anyLong(), anyString())).thenReturn("mockRefreshToken");
+        when(jwtTokenProvider.createRefreshToken(anyLong(), anyString(), any(UserRole.class))).thenReturn("mockRefreshToken");
 
         // When
         User result = userService.processUser(userDTO);


### PR DESCRIPTION
# Pull Request (PR)

## Description

DTO 객체 없이 Map 반환 리팩터
> 테스트 코드 리팩토링

## Changes

- Builder 패턴을 사용하도록 엔티티 초기화 코드 변경
  - setter 대신 Builder 패턴 사용하여 코드 가독성 및 유지보수성 향상
  - 일관된 방식으로 객체 생성 코드 통일
- 테스트 코드 내 Mockito 사용 방식 개선
  - 불필요한 stubbing 제거
  - 명확한 matcher 사용 (eq(), any() 등)
  - 테스트 간 독립성 향상을 위해 각 테스트마다 필요한 mock 객체 생성
- 실제 메소드 시그니처와 테스트 코드 불일치 수정
  - DiaryService, PlantService 테스트의 매개변수 타입 및 개수 일치
  - JwtTokenProvider 메소드 호출 시 필요한 UserRole 파라미터 추가
- Reflection을 사용하여 엔티티의 setter 없는 필드 설정 추가
  - ID, role, createdAt 등 필드 설정에 리플렉션 사용

## Type of Change

- [x] Refactoring/Technical debt
- [x] Bug fix

## How Has This Been Tested?

- 수정된 각 테스트 파일별로 단위 테스트 실행
  - DiaryServiceTest
  - PlantServiceTest
  - UserControllerTest
  - UserServiceTest
- 개별 컴파일 에러 및 런타임 에러 해결 확인
- 테스트 실행 결과 모든 테스트 성공 확인


## Additional Information

주요 수정 내용:
- User.builder()에서 role 메소드 없어 리플렉션으로 설정
- JwtTokenProvider.createRefreshToken 메소드 호출 시 파라미터 추가
- DiaryService.findDiary, addDiary, deleteDiary 메소드의 시그니처 변경 반영
- 불필요한 stubbing 및 잘못된 matcher 사용 수정
- 각 테스트 클래스에서 실제 구현과 일치하도록 필드 이름 및 접근 방식 수정
