### PR TITLE
refactor: 아키텍처 및 예외 처리 개선

### DIFF
--- a/src/main/java/com/jung/planet/admin/dto/PremiumUserDTO.java
+++ b/src/main/java/com/jung/planet/admin/dto/PremiumUserDTO.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 
-@Setter
+@Builder
 @Getter
 public class PremiumUserDTO {
     private String email;

--- a/src/main/java/com/jung/planet/admin/mapper/AdminMapper.java
+++ b/src/main/java/com/jung/planet/admin/mapper/AdminMapper.java
@@ -1,0 +1,26 @@
+package com.jung.planet.admin.mapper;
+
+import com.jung.planet.admin.dto.PremiumUserDTO;
+import com.jung.planet.user.entity.User;
+import org.springframework.stereotype.Component;
+
+/**
+ * Admin 관련 엔티티와 DTO 간 변환을 담당하는 Mapper 클래스
+ */
+@Component
+public class AdminMapper {
+
+    /**
+     * User 엔티티를 PremiumUserDTO로 변환합니다.
+     *
+     * @param user User 엔티티
+     * @return PremiumUserDTO
+     */
+    public PremiumUserDTO toPremiumUserDto(User user) {
+        PremiumUserDTO premiumUserDTO = new PremiumUserDTO();
+        premiumUserDTO.setEmail(user.getEmail());
+        premiumUserDTO.setName(user.getName());
+        premiumUserDTO.setSubscription(user.getSubscription());
+        return premiumUserDTO;
+    }
+}

--- a/src/main/java/com/jung/planet/admin/service/AdminService.java
+++ b/src/main/java/com/jung/planet/admin/service/AdminService.java
@@ -1,9 +1,9 @@
 package com.jung.planet.admin.service;
 
 import com.jung.planet.admin.dto.PremiumUserDTO;
+import com.jung.planet.admin.mapper.AdminMapper;
 import com.jung.planet.user.entity.Subscription;
 import com.jung.planet.user.entity.SubscriptionType;
-import com.jung.planet.user.entity.User;
 import com.jung.planet.user.repository.SubscriptionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,21 +18,14 @@ import java.util.stream.Collectors;
 public class AdminService {
 
     private final SubscriptionRepository subscriptionRepository;
+    private final AdminMapper adminMapper;
 
     @Transactional(readOnly = true)
     public List<PremiumUserDTO> getAllPremiumUsers() {
         List<Subscription> premiumSubscriptions = subscriptionRepository.findByType(SubscriptionType.PREMIUM);
         return premiumSubscriptions.stream()
                 .map(Subscription::getUser)
-                .map(this::convertUserToUserSubscriptionDTO)
+                .map(adminMapper::toPremiumUserDto)
                 .collect(Collectors.toList());
-    }
-
-    private PremiumUserDTO convertUserToUserSubscriptionDTO(User user) {
-        PremiumUserDTO premiumUserDTO = new PremiumUserDTO();
-        premiumUserDTO.setEmail(user.getEmail());
-        premiumUserDTO.setName(user.getName());
-        premiumUserDTO.setSubscription(user.getSubscription());
-        return premiumUserDTO;
     }
 }

--- a/src/main/java/com/jung/planet/common/service/AuthorizationService.java
+++ b/src/main/java/com/jung/planet/common/service/AuthorizationService.java
@@ -1,0 +1,34 @@
+package com.jung.planet.common.service;
+
+import com.jung.planet.exception.ResourceNotFoundException;
+import com.jung.planet.plant.entity.Plant;
+import com.jung.planet.plant.repository.PlantRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 권한 검사를 담당하는 공통 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthorizationService {
+
+    private final PlantRepository plantRepository;
+
+    /**
+     * 사용자가 특정 식물의 소유자인지 확인합니다.
+     *
+     * @param userId 사용자 ID
+     * @param plantId 식물 ID
+     * @return 소유자 여부
+     * @throws ResourceNotFoundException 식물을 찾을 수 없는 경우
+     */
+    @Transactional(readOnly = true)
+    public boolean isOwnerOfPlant(Long userId, Long plantId) {
+        Plant plant = plantRepository.findById(plantId)
+                .orElseThrow(() -> new ResourceNotFoundException("Plant", "id", plantId));
+
+        return plant.getUser().getId().equals(userId);
+    }
+}

--- a/src/main/java/com/jung/planet/diary/controller/DiaryController.java
+++ b/src/main/java/com/jung/planet/diary/controller/DiaryController.java
@@ -77,7 +77,7 @@ public class DiaryController {
         @ApiResponse(responseCode = "403", description = "권한 없음"),
         @ApiResponse(responseCode = "500", description = "서버 내부 오류")
     })
-    @PostMapping("/edit/{id}")
+    @PutMapping("/{id}")
     public ApiResponseDTO<DiaryResponseDTO> editDiary(
         @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal CustomUserDetails customUserDetails,
         @Parameter(description = "다이어리 ID") @PathVariable("id") Long diaryId,

--- a/src/main/java/com/jung/planet/diary/dto/DiaryDTO.java
+++ b/src/main/java/com/jung/planet/diary/dto/DiaryDTO.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 
 
 @Getter
-@Setter
+@Builder
 public class DiaryDTO {
 
     @NotNull(message = "plant를 찾을 수 없습니다.")

--- a/src/main/java/com/jung/planet/diary/dto/DiaryDetailDTO.java
+++ b/src/main/java/com/jung/planet/diary/dto/DiaryDetailDTO.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 
 @Getter
-@Setter
+@Builder
 public class DiaryDetailDTO {
     private Long id;
     private String content;

--- a/src/main/java/com/jung/planet/diary/entity/Diary.java
+++ b/src/main/java/com/jung/planet/diary/entity/Diary.java
@@ -36,7 +36,7 @@ public class Diary {
     @Column(nullable = false, columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "created_at", nullable = false, updatable = true)
+    @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 
     @JsonIgnore

--- a/src/main/java/com/jung/planet/diary/entity/Diary.java
+++ b/src/main/java/com/jung/planet/diary/entity/Diary.java
@@ -52,16 +52,33 @@ public class Diary {
         this.createdAt = createdAt != null ? createdAt : LocalDateTime.now(); // 조건부 설정
     }
 
-
-    public void setPublic(Boolean aPublic) {
-        isPublic = aPublic;
-    }
-
-    public void setImgUrl(String imgUrl) {
-        this.imgUrl = imgUrl;
-    }
-
-    public void setContent(String content) {
+    /**
+     * 다이어리 내용을 수정합니다.
+     */
+    public void updateContent(String content) {
+        if (content == null || content.isBlank()) {
+            throw new IllegalArgumentException("다이어리 내용은 필수입니다.");
+        }
         this.content = content;
+    }
+
+    /**
+     * 다이어리 공개 여부를 변경합니다.
+     */
+    public void updateVisibility(Boolean isPublic) {
+        if (isPublic == null) {
+            throw new IllegalArgumentException("공개 여부는 null일 수 없습니다.");
+        }
+        this.isPublic = isPublic;
+    }
+
+    /**
+     * 다이어리 이미지 URL을 수정합니다.
+     */
+    public void updateImageUrl(String imgUrl) {
+        if (imgUrl == null || imgUrl.isBlank()) {
+            throw new IllegalArgumentException("이미지 URL은 필수입니다.");
+        }
+        this.imgUrl = imgUrl;
     }
 }

--- a/src/main/java/com/jung/planet/diary/service/DiaryService.java
+++ b/src/main/java/com/jung/planet/diary/service/DiaryService.java
@@ -58,44 +58,34 @@ public class DiaryService {
 
     @Transactional
     public void editDiary(CustomUserDetails customUserDetails, Long diaryId, DiaryFormDTO diaryFormDTO) {
-        if (diaryRepository.existsById(diaryId)) {
-            Optional<Diary> diary = diaryRepository.findByIdAndUserId(diaryId, customUserDetails.getUserId());
+        Diary diary = diaryRepository.findByIdAndUserId(diaryId, customUserDetails.getUserId())
+                .orElseThrow(() -> new AccessDeniedException("다이어리를 찾을 수 없거나 수정 권한이 없습니다. diaryId: " + diaryId));
 
-            if (diary.isPresent()) {
-                ByteBuffer imageBuffer = ByteBuffer.wrap(Base64.getDecoder().decode(diaryFormDTO.getImgData()));
+        ByteBuffer imageBuffer = ByteBuffer.wrap(Base64.getDecoder().decode(diaryFormDTO.getImgData()));
 
-                diary.get().setContent(diaryFormDTO.getContent());
-                diary.get().setPublic(diaryFormDTO.getIsPublic());
+        diary.setContent(diaryFormDTO.getContent());
+        diary.setPublic(diaryFormDTO.getIsPublic());
 
-                cloudflareR2Uploader.editDiaryImage(customUserDetails.getUsername(), diary.get(), imageBuffer);
+        cloudflareR2Uploader.editDiaryImage(customUserDetails.getUsername(), diary, imageBuffer);
 
-                diaryRepository.save(diary.get());
-
-            } else {
-                // 소유자가 아닌 경우 예외 발생
-                throw new AccessDeniedException("No access rights to delete diary with ID " + diaryId);
-            }
-        } else {
-            throw new EntityNotFoundException("다이어리 데이터를 찾을 수 없습니다.");
-        }
+        diaryRepository.save(diary);
     }
 
     @Transactional
     public void deleteDiary(Long diaryId, CustomUserDetails customUserDetails) {
-        Optional<Diary> diary = diaryRepository.findById(diaryId);
+        Diary diary = diaryRepository.findById(diaryId)
+                .orElseThrow(() -> new EntityNotFoundException("다이어리 데이터를 찾을 수 없습니다."));
 
-        if (diary.isPresent()) {
-            // 어드민이거나 일기의 소유자일 경우 삭제 허용
-            if (customUserDetails.getUserRole().equals(UserRole.ADMIN) || diary.get().getPlant().getUser().getId().equals(customUserDetails.getUserId())) {
-                diaryRepository.deleteById(diaryId);
-                cloudflareR2Uploader.deleteDiary(diary.get(), customUserDetails.getUsername());
-            } else {
-                // 소유자가 아닌 경우 예외 발생
-                throw new AccessDeniedException("No access rights to delete diary with ID " + diaryId);
-            }
-        } else {
-            throw new EntityNotFoundException("다이어리 데이터를 찾을 수 없습니다.");
+        // 어드민이거나 일기의 소유자일 경우 삭제 허용
+        boolean isAdmin = customUserDetails.getUserRole().equals(UserRole.ADMIN);
+        boolean isOwner = diary.getPlant().getUser().getId().equals(customUserDetails.getUserId());
+
+        if (!isAdmin && !isOwner) {
+            throw new AccessDeniedException("다이어리 삭제 권한이 없습니다. diaryId: " + diaryId);
         }
+
+        diaryRepository.deleteById(diaryId);
+        cloudflareR2Uploader.deleteDiary(diary, customUserDetails.getUsername());
     }
 
 

--- a/src/main/java/com/jung/planet/diary/service/DiaryService.java
+++ b/src/main/java/com/jung/planet/diary/service/DiaryService.java
@@ -63,8 +63,8 @@ public class DiaryService {
 
         ByteBuffer imageBuffer = ByteBuffer.wrap(Base64.getDecoder().decode(diaryFormDTO.getImgData()));
 
-        diary.setContent(diaryFormDTO.getContent());
-        diary.setPublic(diaryFormDTO.getIsPublic());
+        diary.updateContent(diaryFormDTO.getContent());
+        diary.updateVisibility(diaryFormDTO.getIsPublic());
 
         cloudflareR2Uploader.editDiaryImage(customUserDetails.getUsername(), diary, imageBuffer);
 
@@ -90,15 +90,14 @@ public class DiaryService {
 
 
     private DiaryDetailDTO convertToDiaryDetailDTO(Diary diary, boolean isOwner) {
-        DiaryDetailDTO diaryDetailDTO = new DiaryDetailDTO();
-        diaryDetailDTO.setId(diary.getId());
-        diaryDetailDTO.setContent(diary.getContent());
-        diaryDetailDTO.setImgUrl(diary.getImgUrl());
-        diaryDetailDTO.setPublic(diary.getIsPublic());
-        diaryDetailDTO.setCreatedAt(diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-        diaryDetailDTO.setMine(isOwner);
-
-        return diaryDetailDTO;
+        return DiaryDetailDTO.builder()
+                .id(diary.getId())
+                .content(diary.getContent())
+                .imgUrl(diary.getImgUrl())
+                .isPublic(diary.getIsPublic())
+                .createdAt(diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
+                .isMine(isOwner)
+                .build();
     }
 
 

--- a/src/main/java/com/jung/planet/plant/controller/PlantController.java
+++ b/src/main/java/com/jung/planet/plant/controller/PlantController.java
@@ -135,21 +135,16 @@ public class PlantController {
             @PathVariable("id") Long plantId) {
         Long userId = customUserDetails.getUserId();
         logger.debug("userId :: {}", userId);
-        
+
         // 식물 소유권 확인
         if (!plantService.isOwnerOfPlant(userId, plantId)) {
             throw new PermissionDeniedException("Plant", plantId);
         }
 
-        try {
-            plantFormDTO.setUserId(userId);
-            Plant newPlant = plantService.editPlant(plantFormDTO, plantId);
-            logger.info("Plant edited: {}", newPlant);
-            return ApiResponseDTO.success(PlantResponseDTO.forSinglePlant(newPlant.getId()), "식물이 성공적으로 수정되었습니다.");
-        } catch (Exception e) {
-            logger.error("Error editing plant: {}", e.getMessage());
-            return ApiResponseDTO.<PlantResponseDTO>error(ErrorMessages.SERVER_ERROR, PlantResponseDTO.builder().success(false).build());
-        }
+        plantFormDTO.setUserId(userId);
+        Plant newPlant = plantService.editPlant(plantFormDTO, plantId);
+        logger.info("Plant edited: {}", newPlant);
+        return ApiResponseDTO.success(PlantResponseDTO.forSinglePlant(newPlant.getId()), "식물이 성공적으로 수정되었습니다.");
     }
 
     @Operation(summary = "식물 삭제", description = "ID로 특정 식물을 삭제합니다.")

--- a/src/main/java/com/jung/planet/plant/controller/PlantController.java
+++ b/src/main/java/com/jung/planet/plant/controller/PlantController.java
@@ -125,7 +125,7 @@ public class PlantController {
         @ApiResponse(responseCode = "500", description = "서버 내부 오류",
             content = @Content(schema = @Schema(implementation = ApiResponseDTO.class)))
     })
-    @PostMapping("/edit/{id}")
+    @PutMapping("/{id}")
     public ApiResponseDTO<PlantResponseDTO> editPlant(
             @Parameter(hidden = true)
             @AuthenticationPrincipal CustomUserDetails customUserDetails,

--- a/src/main/java/com/jung/planet/plant/controller/PlantController.java
+++ b/src/main/java/com/jung/planet/plant/controller/PlantController.java
@@ -1,6 +1,7 @@
 package com.jung.planet.plant.controller;
 
 import com.jung.planet.common.dto.ApiResponseDTO;
+import com.jung.planet.common.service.AuthorizationService;
 import com.jung.planet.exception.ErrorMessages;
 import com.jung.planet.exception.PermissionDeniedException;
 import com.jung.planet.exception.UnauthorizedActionException;
@@ -38,6 +39,7 @@ public class PlantController {
     private static final Logger logger = LoggerFactory.getLogger(PlantController.class);
 
     private final PlantService plantService;
+    private final AuthorizationService authorizationService;
 
     @Operation(summary = "식물 목록 조회", description = "모든 식물의 목록을 조회합니다.")
     @ApiResponses({
@@ -137,7 +139,7 @@ public class PlantController {
         logger.debug("userId :: {}", userId);
 
         // 식물 소유권 확인
-        if (!plantService.isOwnerOfPlant(userId, plantId)) {
+        if (!authorizationService.isOwnerOfPlant(userId, plantId)) {
             throw new PermissionDeniedException("Plant", plantId);
         }
 
@@ -169,7 +171,7 @@ public class PlantController {
         Long userId = customUserDetails.getUserId();
         String userEmail = customUserDetails.getUsername();
 
-        if (!plantService.isOwnerOfPlant(userId, plantId) && !customUserDetails.getUserRole().equals(UserRole.ADMIN)) {
+        if (!authorizationService.isOwnerOfPlant(userId, plantId) && !customUserDetails.getUserRole().equals(UserRole.ADMIN)) {
             throw new UnauthorizedActionException(ErrorMessages.PLANT_PERMISSION_DENIED);
         }
 

--- a/src/main/java/com/jung/planet/plant/dto/PlantDTO.java
+++ b/src/main/java/com/jung/planet/plant/dto/PlantDTO.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
+@Builder
 public class PlantDTO {
 
     private Long userId;

--- a/src/main/java/com/jung/planet/plant/dto/PlantDetailDTO.java
+++ b/src/main/java/com/jung/planet/plant/dto/PlantDetailDTO.java
@@ -8,7 +8,7 @@ import java.util.List;
 
 
 @Getter
-@Setter
+@Builder
 public class PlantDetailDTO {
 
     private Long plantId;

--- a/src/main/java/com/jung/planet/plant/dto/PlantSummaryDTO.java
+++ b/src/main/java/com/jung/planet/plant/dto/PlantSummaryDTO.java
@@ -5,7 +5,7 @@ import lombok.Setter;
 
 
 
-@Setter
+@Builder
 @Getter
 public class PlantSummaryDTO {
     private Long id;

--- a/src/main/java/com/jung/planet/plant/entity/Plant.java
+++ b/src/main/java/com/jung/planet/plant/entity/Plant.java
@@ -52,15 +52,34 @@ public class Plant {
     @OneToMany(mappedBy = "reportedPlant", cascade = CascadeType.ALL)
     private Set<Report> reports;
 
-    public void setNickName(String nickName) {
+    /**
+     * 식물 정보를 업데이트합니다.
+     *
+     * @param nickName 식물 애칭
+     * @param scientificName 학명
+     * @throws IllegalArgumentException 필수 값이 null이거나 비어있는 경우
+     */
+    public void updatePlantInfo(String nickName, String scientificName) {
+        if (nickName == null || nickName.isBlank()) {
+            throw new IllegalArgumentException("식물 이름은 필수입니다.");
+        }
+        if (scientificName == null || scientificName.isBlank()) {
+            throw new IllegalArgumentException("학명은 필수입니다.");
+        }
         this.nickName = nickName;
-    }
-
-    public void setScientificName(String scientificName) {
         this.scientificName = scientificName;
     }
 
-    public void setImgUrl(String imgUrl) {
+    /**
+     * 식물 이미지 URL을 업데이트합니다.
+     *
+     * @param imgUrl 이미지 URL
+     * @throws IllegalArgumentException URL이 null이거나 비어있는 경우
+     */
+    public void updateImageUrl(String imgUrl) {
+        if (imgUrl == null || imgUrl.isBlank()) {
+            throw new IllegalArgumentException("이미지 URL은 필수입니다.");
+        }
         this.imgUrl = imgUrl;
     }
 

--- a/src/main/java/com/jung/planet/plant/mapper/PlantMapper.java
+++ b/src/main/java/com/jung/planet/plant/mapper/PlantMapper.java
@@ -1,0 +1,101 @@
+package com.jung.planet.plant.mapper;
+
+import com.jung.planet.diary.dto.DiaryDetailDTO;
+import com.jung.planet.diary.entity.Diary;
+import com.jung.planet.plant.dto.PlantDetailDTO;
+import com.jung.planet.plant.dto.PlantSummaryDTO;
+import com.jung.planet.plant.entity.Plant;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+/**
+ * Plant 엔티티와 DTO 간 변환을 담당하는 Mapper 클래스
+ */
+@Component
+public class PlantMapper {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    /**
+     * Plant 엔티티를 PlantSummaryDTO로 변환합니다.
+     *
+     * @param plant Plant 엔티티
+     * @return PlantSummaryDTO
+     */
+    public PlantSummaryDTO toSummaryDto(Plant plant) {
+        PlantSummaryDTO dto = new PlantSummaryDTO();
+        dto.setId(plant.getId());
+        dto.setNickName(plant.getNickName());
+        dto.setHeartCount(plant.getHeartCount());
+        dto.setImgUrl(plant.getImgUrl());
+        dto.setPeriod(calculatePeriod(plant.getCreatedAt()));
+        return dto;
+    }
+
+    /**
+     * Plant 엔티티를 PlantDetailDTO로 변환합니다.
+     *
+     * @param userId 현재 사용자 ID
+     * @param plant Plant 엔티티
+     * @param isHearted 좋아요 여부
+     * @return PlantDetailDTO
+     */
+    public PlantDetailDTO toDetailDto(Long userId, Plant plant, boolean isHearted) {
+        boolean isMine = Objects.equals(plant.getUser().getId(), userId);
+
+        PlantDetailDTO dto = new PlantDetailDTO();
+        dto.setPlantId(plant.getId());
+        dto.setNickName(plant.getNickName());
+        dto.setScientificName(plant.getScientificName());
+        dto.setImgUrl(plant.getImgUrl());
+        dto.setHeartCount(plant.getHeartCount());
+        dto.setPeriod(calculatePeriod(plant.getCreatedAt()));
+        dto.setMine(isMine);
+        dto.setHearted(isHearted);
+        dto.setCreatedAt(plant.getCreatedAt().format(DATE_FORMATTER));
+
+        List<DiaryDetailDTO> diaryDTOs = plant.getDiaries().stream()
+                .map(diary -> toDiaryDetailDto(diary, userId))
+                .collect(Collectors.toList());
+        dto.setDiaries(diaryDTOs);
+
+        return dto;
+    }
+
+    /**
+     * Diary 엔티티를 DiaryDetailDTO로 변환합니다.
+     *
+     * @param diary Diary 엔티티
+     * @param userId 현재 사용자 ID
+     * @return DiaryDetailDTO
+     */
+    public DiaryDetailDTO toDiaryDetailDto(Diary diary, Long userId) {
+        DiaryDetailDTO diaryDTO = new DiaryDetailDTO();
+        diaryDTO.setId(diary.getId());
+        diaryDTO.setContent(diary.getContent());
+        diaryDTO.setPublic(diary.getIsPublic());
+        diaryDTO.setImgUrl(diary.getImgUrl());
+        diaryDTO.setCreatedAt(diary.getCreatedAt().format(DATE_FORMATTER));
+
+        boolean isMine = diary.getPlant().getUser().getId().equals(userId);
+        diaryDTO.setMine(isMine);
+
+        return diaryDTO;
+    }
+
+    /**
+     * 생성일로부터 경과한 일수를 계산합니다.
+     *
+     * @param createdAt 생성일시
+     * @return 경과 일수
+     */
+    private int calculatePeriod(LocalDateTime createdAt) {
+        return (int) ChronoUnit.DAYS.between(createdAt, LocalDateTime.now());
+    }
+}

--- a/src/main/java/com/jung/planet/plant/repository/PlantRepository.java
+++ b/src/main/java/com/jung/planet/plant/repository/PlantRepository.java
@@ -14,16 +14,21 @@ import java.util.List;
 public interface PlantRepository extends JpaRepository<Plant, Long> {
     List<Plant> findByUserId(Long userId);
 
-    boolean existsByIdAndUserId(Long plantId, Long userId);
+    boolean existsByIdAndUserId(Long id, Long userId);
 
     Page<Plant> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
-
+    /**
+     * 랜덤으로 5개의 식물을 조회합니다.
+     * 데이터베이스 독립적인 방식으로 구현하기 위해 애플리케이션 레벨에서 랜덤 처리를 권장하지만,
+     * 성능을 위해 네이티브 쿼리를 유지합니다.
+     */
     @Query(value = "SELECT * FROM plant ORDER BY RAND() LIMIT 5", nativeQuery = true)
-    List<Plant> findRandomPlants();
+    List<Plant> findTop5ByRandom();
 
-
-    // 사용자 ID를 기반으로 하트의 총합을 계산하는 쿼리
+    /**
+     * 사용자가 소유한 모든 식물의 하트 개수 합계를 계산합니다.
+     */
     @Query("SELECT SUM(p.heartCount) FROM Plant p WHERE p.user.id = :userId")
-    Integer sumHeartsByUserId(@Param("userId") Long userId);
+    Integer sumHeartCountByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/jung/planet/plant/service/PlantService.java
+++ b/src/main/java/com/jung/planet/plant/service/PlantService.java
@@ -1,5 +1,6 @@
 package com.jung.planet.plant.service;
 
+import com.jung.planet.common.service.AuthorizationService;
 import com.jung.planet.diary.dto.DiaryDetailDTO;
 import com.jung.planet.diary.entity.Diary;
 import com.jung.planet.exception.PermissionDeniedException;
@@ -10,6 +11,7 @@ import com.jung.planet.plant.dto.PlantSummaryDTO;
 import com.jung.planet.plant.dto.request.PlantFormDTO;
 import com.jung.planet.plant.entity.Plant;
 import com.jung.planet.plant.entity.UserPlantHeart;
+import com.jung.planet.plant.mapper.PlantMapper;
 import com.jung.planet.plant.repository.PlantRepository;
 import com.jung.planet.plant.repository.UserPlantHeartRepository;
 import com.jung.planet.r2.CloudflareR2Uploader;
@@ -42,6 +44,8 @@ public class PlantService {
     private final UserRepository userRepository;
     private final UserPlantHeartRepository userPlantHeartRepository;
     private final CloudflareR2Uploader cloudflareR2Uploader;
+    private final PlantMapper plantMapper;
+    private final AuthorizationService authorizationService;
 
     @Transactional
     public Plant addPlant(PlantFormDTO plantFormDTO) {
@@ -150,7 +154,7 @@ public class PlantService {
         Page<UserPlantHeart> hearts = userPlantHeartRepository.findByUserId(userId, pageable);
 
         return hearts.stream()
-                .map(heart -> convertToDto(heart.getPlant()))
+                .map(heart -> plantMapper.toSummaryDto(heart.getPlant()))
                 .collect(Collectors.toList());
     }
 
@@ -179,69 +183,11 @@ public class PlantService {
         
         boolean isHearted = userPlantHeartRepository.findByUserIdAndPlantId(userId, plantId).isPresent();
 
-        return convertToDetailDto(userId, plant, isHearted);
+        return plantMapper.toDetailDto(userId, plant, isHearted);
     }
 
     public int getTotalHearts(Long userId) {
         Integer totalHearts = plantRepository.sumHeartsByUserId(userId);
         return totalHearts != null ? totalHearts : 0;
-    }
-
-    private PlantSummaryDTO convertToDto(Plant plant) {
-        PlantSummaryDTO dto = new PlantSummaryDTO();
-        dto.setId(plant.getId());
-        dto.setNickName(plant.getNickName());
-        dto.setHeartCount(plant.getHeartCount());
-        dto.setImgUrl(plant.getImgUrl());
-        dto.setPeriod(calculatePeriod(plant.getCreatedAt()));
-        return dto;
-    }
-
-    private PlantDetailDTO convertToDetailDto(Long userId, Plant plant, boolean isHearted) {
-        boolean isMine = Objects.equals(plant.getUser().getId(), userId);
-
-        PlantDetailDTO dto = new PlantDetailDTO();
-        dto.setPlantId(plant.getId());
-        dto.setNickName(plant.getNickName());
-        dto.setScientificName(plant.getScientificName());
-        dto.setImgUrl(plant.getImgUrl());
-        dto.setHeartCount(plant.getHeartCount());
-        dto.setPeriod(calculatePeriod(plant.getCreatedAt()));
-        dto.setMine(isMine);
-        dto.setHearted(isHearted);
-        dto.setCreatedAt(plant.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-
-        List<DiaryDetailDTO> diaryDTOs = plant.getDiaries().stream()
-                .map(diary -> convertToDiaryDto(diary, userId))
-                .collect(Collectors.toList());
-        dto.setDiaries(diaryDTOs);
-
-        return dto;
-    }
-
-    private DiaryDetailDTO convertToDiaryDto(Diary diary, Long userId) {
-        DiaryDetailDTO diaryDTO = new DiaryDetailDTO();
-        diaryDTO.setId(diary.getId());
-        diaryDTO.setContent(diary.getContent());
-        diaryDTO.setPublic(diary.getIsPublic());
-        diaryDTO.setImgUrl(diary.getImgUrl());
-        diaryDTO.setCreatedAt(diary.getCreatedAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")));
-
-        boolean isMine = diary.getPlant().getUser().getId().equals(userId);
-        diaryDTO.setMine(isMine);
-
-        return diaryDTO;
-    }
-
-    private int calculatePeriod(LocalDateTime createdAt) {
-        return (int) ChronoUnit.DAYS.between(createdAt, LocalDateTime.now());
-    }
-
-    public boolean isOwnerOfPlant(Long userId, Long plantId) {
-        // Plant 존재 여부 확인
-        if (!plantRepository.existsById(plantId)) {
-            throw new ResourceNotFoundException("Plant", "id", plantId);
-        }
-        return plantRepository.existsByIdAndUserId(plantId, userId);
     }
 }

--- a/src/main/java/com/jung/planet/plant/service/PlantService.java
+++ b/src/main/java/com/jung/planet/plant/service/PlantService.java
@@ -159,7 +159,7 @@ public class PlantService {
 
     @Transactional(readOnly = true)
     public List<PlantSummaryDTO> getRandomPlants() {
-        List<Plant> randomPlants = plantRepository.findRandomPlants();
+        List<Plant> randomPlants = plantRepository.findTop5ByRandom();
 
         if (randomPlants == null || randomPlants.isEmpty()) {
             return Collections.emptyList();
@@ -185,8 +185,9 @@ public class PlantService {
         return plantMapper.toDetailDto(userId, plant, isHearted);
     }
 
+    @Transactional(readOnly = true)
     public int getTotalHearts(Long userId) {
-        Integer totalHearts = plantRepository.sumHeartsByUserId(userId);
+        Integer totalHearts = plantRepository.sumHeartCountByUserId(userId);
         return totalHearts != null ? totalHearts : 0;
     }
 }

--- a/src/main/java/com/jung/planet/plant/service/PlantService.java
+++ b/src/main/java/com/jung/planet/plant/service/PlantService.java
@@ -36,6 +36,8 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 public class PlantService {
+    private static final int DEFAULT_PAGE_SIZE = 4;
+
     private final PlantRepository plantRepository;
     private final UserRepository userRepository;
     private final UserPlantHeartRepository userPlantHeartRepository;
@@ -118,7 +120,7 @@ public class PlantService {
 
     @Transactional(readOnly = true)
     public List<PlantSummaryDTO> getPlantsByRecent(int page) {
-        Pageable pageable = PageRequest.of(page, 4, Sort.by("createdAt").descending());
+        Pageable pageable = PageRequest.of(page, DEFAULT_PAGE_SIZE, Sort.by("createdAt").descending());
         Page<Plant> plantPage = plantRepository.findAllByOrderByCreatedAtDesc(pageable);
         if (plantPage.isEmpty()) {
             return Collections.emptyList();
@@ -130,7 +132,7 @@ public class PlantService {
 
     @Transactional(readOnly = true)
     public List<PlantSummaryDTO> getPlantsByPopularity(int page) {
-        Pageable pageable = PageRequest.of(page, 4, Sort.by("heartCount").descending());
+        Pageable pageable = PageRequest.of(page, DEFAULT_PAGE_SIZE, Sort.by("heartCount").descending());
         Page<Plant> plantPage = plantRepository.findAll(pageable);
 
         if (plantPage.isEmpty()) {
@@ -144,7 +146,7 @@ public class PlantService {
 
     @Transactional(readOnly = true)
     public List<PlantSummaryDTO> getHeartedPlantsByUser(Long userId, int page) {
-        Pageable pageable = PageRequest.of(page, 4);
+        Pageable pageable = PageRequest.of(page, DEFAULT_PAGE_SIZE);
         Page<UserPlantHeart> hearts = userPlantHeartRepository.findByUserId(userId, pageable);
 
         return hearts.stream()

--- a/src/main/java/com/jung/planet/plant/service/PlantService.java
+++ b/src/main/java/com/jung/planet/plant/service/PlantService.java
@@ -84,8 +84,7 @@ public class PlantService {
             throw new ExternalServiceException("이미지 업로드 서비스", "식물 이미지 수정", e);
         }
 
-        plant.setNickName(plantFormDTO.getNickName());
-        plant.setScientificName(plantFormDTO.getScientificName());
+        plant.updatePlantInfo(plantFormDTO.getNickName(), plantFormDTO.getScientificName());
 
         return plantRepository.save(plant);
     }

--- a/src/main/java/com/jung/planet/plant/service/UserPlantHeartService.java
+++ b/src/main/java/com/jung/planet/plant/service/UserPlantHeartService.java
@@ -1,6 +1,7 @@
 package com.jung.planet.plant.service;
 
 
+import com.jung.planet.common.service.AuthorizationService;
 import com.jung.planet.exception.UnauthorizedActionException;
 import com.jung.planet.plant.entity.Plant;
 import com.jung.planet.plant.entity.UserPlantHeart;
@@ -23,6 +24,7 @@ public class UserPlantHeartService {
     private final UserPlantHeartRepository userPlantHeartRepository;
     private final UserRepository userRepository;
     private final PlantRepository plantRepository;
+    private final AuthorizationService authorizationService;
 
 
     @Transactional
@@ -33,7 +35,7 @@ public class UserPlantHeartService {
                 .orElseThrow(() -> new EntityNotFoundException("Plant not found"));
 
         // 식물의 소유자가 아닌 경우에만 토글 허용
-        if (!isOwnerOfPlant(userId, plantId)) {
+        if (!authorizationService.isOwnerOfPlant(userId, plantId)) {
 
             UserPlantHeartId userPlantHeartId = new UserPlantHeartId(userId, plantId);
             Optional<UserPlantHeart> userPlantHeart = userPlantHeartRepository.findById(userPlantHeartId);
@@ -56,14 +58,5 @@ public class UserPlantHeartService {
             // 식물의 소유자인 경우, 토글을 거부하고 예외 처리 또는 적절한 응답 반환
             throw new UnauthorizedActionException("자신의 식물엔 좋아요를 누를 수 없습니다.");
         }
-
-
     }
-
-
-    public boolean isOwnerOfPlant(Long userId, Long plantId) {
-        return plantRepository.existsByIdAndUserId(plantId, userId);
-    }
-
-
 }

--- a/src/main/java/com/jung/planet/r2/CloudFlareR2Utils.java
+++ b/src/main/java/com/jung/planet/r2/CloudFlareR2Utils.java
@@ -1,18 +1,29 @@
 package com.jung.planet.r2;
 
+import com.jung.planet.exception.ExternalServiceException;
+import org.springframework.stereotype.Component;
+
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
+@Component
 public class CloudFlareR2Utils {
-    String calculateImageHash(ByteBuffer imageBuffer) {
+
+    /**
+     * 이미지 버퍼의 SHA-256 해시값을 계산합니다.
+     *
+     * @param imageBuffer 이미지 버퍼
+     * @return Base64로 인코딩된 해시값
+     */
+    public String calculateImageHash(ByteBuffer imageBuffer) {
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(imageBuffer.array());
             return Base64.getEncoder().encodeToString(hash);
         } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("Failed to calculate image hash", e);
+            throw new ExternalServiceException("이미지 해시 계산 중 오류가 발생했습니다.", e);
         }
     }
 }

--- a/src/main/java/com/jung/planet/r2/CloudflarePurgeCache.java
+++ b/src/main/java/com/jung/planet/r2/CloudflarePurgeCache.java
@@ -9,14 +9,14 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 @Component
-public class CloudFlarePurgeCache {
+public class CloudflarePurgeCache {
 
     private final String cloudflareXAuthEmail;
     private final String cloudflareXAuthKey;
 
     private final String purgeEndpoint;
 
-    public CloudFlarePurgeCache(@Value("${cloudflareR2.email}") String cloudflareXAuthEmail, @Value("${cloudflareR2.global_api_key}") String cloudflareXAuthKey, @Value("${cloudflareR2.zone_id}") String zoneId) {
+    public CloudflarePurgeCache(@Value("${cloudflareR2.email}") String cloudflareXAuthEmail, @Value("${cloudflareR2.global_api_key}") String cloudflareXAuthKey, @Value("${cloudflareR2.zone_id}") String zoneId) {
         this.cloudflareXAuthEmail = cloudflareXAuthEmail;
         this.cloudflareXAuthKey = cloudflareXAuthKey;
         this.purgeEndpoint = "https://api.cloudflare.com/client/v4/zones/" + zoneId + "/purge_cache";

--- a/src/main/java/com/jung/planet/r2/CloudflarePurgeCache.java
+++ b/src/main/java/com/jung/planet/r2/CloudflarePurgeCache.java
@@ -1,5 +1,8 @@
 package com.jung.planet.r2;
 
+import com.jung.planet.exception.ExternalServiceException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -10,6 +13,8 @@ import java.net.URL;
 
 @Component
 public class CloudflarePurgeCache {
+
+    private static final Logger logger = LoggerFactory.getLogger(CloudflarePurgeCache.class);
 
     private final String cloudflareXAuthEmail;
     private final String cloudflareXAuthKey;
@@ -22,18 +27,30 @@ public class CloudflarePurgeCache {
         this.purgeEndpoint = "https://api.cloudflare.com/client/v4/zones/" + zoneId + "/purge_cache";
     }
 
-    // Cloudflare 캐시 purge 메소드
+    /**
+     * Cloudflare 캐시를 purge합니다.
+     *
+     * @param imageUrl 캐시에서 제거할 이미지 URL
+     * @throws ExternalServiceException Cloudflare API 호출 실패 시
+     */
     void purgeCache(String imageUrl) {
         try {
+            logger.debug("Cloudflare 캐시 purge 시작. imageUrl: {}", imageUrl);
+
             URL url = new URL(purgeEndpoint);
             HttpURLConnection conn = getHttpURLConnection(imageUrl, url);
 
             int responseCode = conn.getResponseCode();
-            System.out.println("Response Code : " + responseCode);
+
+            if (responseCode >= 200 && responseCode < 300) {
+                logger.info("Cloudflare 캐시 purge 성공. imageUrl: {}, responseCode: {}", imageUrl, responseCode);
+            } else {
+                logger.warn("Cloudflare 캐시 purge 응답 코드 비정상. imageUrl: {}, responseCode: {}", imageUrl, responseCode);
+            }
 
         } catch (Exception e) {
-            // 예외 처리
-            throw new RuntimeException("Failed to purge Cloudflare cache", e);
+            logger.error("Cloudflare 캐시 purge 실패. imageUrl: {}", imageUrl, e);
+            throw new ExternalServiceException("Cloudflare Cache", "캐시 purge", e);
         }
     }
 

--- a/src/main/java/com/jung/planet/r2/CloudflareR2Uploader.java
+++ b/src/main/java/com/jung/planet/r2/CloudflareR2Uploader.java
@@ -39,8 +39,15 @@ public class CloudflareR2Uploader {
 
 
     @Autowired
-    public CloudflareR2Uploader(CloudFlarePurgeCache cloudFlarePurgeCache, @Value("${cloudflareR2.access_id}") String access_id, @Value("${cloudflareR2.secret_key}") String secret_key, @Value("${cloudflareR2.end_point}") String end_point, @Value("${cloudflareR2.storage_point}") String storage_point, @Value("${cloudflareR2.bucket_name}") String bucket_name) {
-        this.cloudFlareR2Utils = new CloudFlareR2Utils();
+    public CloudflareR2Uploader(
+            CloudFlareR2Utils cloudFlareR2Utils,
+            CloudFlarePurgeCache cloudFlarePurgeCache,
+            @Value("${cloudflareR2.access_id}") String access_id,
+            @Value("${cloudflareR2.secret_key}") String secret_key,
+            @Value("${cloudflareR2.end_point}") String end_point,
+            @Value("${cloudflareR2.storage_point}") String storage_point,
+            @Value("${cloudflareR2.bucket_name}") String bucket_name) {
+        this.cloudFlareR2Utils = cloudFlareR2Utils;
         this.bucketName = bucket_name;
         this.endPointUri = end_point;
         this.storagePointUri = storage_point;

--- a/src/main/java/com/jung/planet/r2/CloudflareR2Uploader.java
+++ b/src/main/java/com/jung/planet/r2/CloudflareR2Uploader.java
@@ -1,6 +1,7 @@
 package com.jung.planet.r2;
 
 import com.jung.planet.diary.entity.Diary;
+import com.jung.planet.exception.ExternalServiceException;
 import com.jung.planet.plant.entity.Plant;
 import com.jung.planet.user.entity.User;
 import lombok.Getter;
@@ -112,8 +113,8 @@ public class CloudflareR2Uploader {
 
 
         } catch (S3Exception e) {
-            // 로그 기록, 예외 처리 로직
-            throw new RuntimeException("파일 삭제 중 오류가 발생했습니다.", e);
+            logger.error("Failed to delete plant files. plantId: {}, userEmail: {}", plantId, userEmail, e);
+            throw new ExternalServiceException("Cloudflare R2", "식물 파일 삭제", e);
         }
     }
 
@@ -177,8 +178,8 @@ public class CloudflareR2Uploader {
 
 
         } catch (S3Exception e) {
-            // 로그 기록, 예외 처리 로직
-            throw new RuntimeException("파일 삭제 중 오류가 발생했습니다.", e);
+            logger.error("Failed to delete diary file. diaryId: {}, userEmail: {}", diary.getId(), userEmail, e);
+            throw new ExternalServiceException("Cloudflare R2", "일기 파일 삭제", e);
         }
     }
 
@@ -204,8 +205,8 @@ public class CloudflareR2Uploader {
 
 
         } catch (S3Exception e) {
-            // 로그 기록, 예외 처리 로직
-            throw new RuntimeException("파일 삭제 중 오류가 발생했습니다.", e);
+            logger.error("Failed to delete user files. userEmail: {}", userEmail, e);
+            throw new ExternalServiceException("Cloudflare R2", "사용자 파일 삭제", e);
         }
     }
 
@@ -231,7 +232,8 @@ public class CloudflareR2Uploader {
 
             return response.metadata().get("image-hash");
         } catch (S3Exception e) {
-            throw new RuntimeException("Failed to retrieve image hash from R2", e);
+            logger.error("Failed to retrieve image hash from R2. filePath: {}", filePath, e);
+            throw new ExternalServiceException("Cloudflare R2", "이미지 해시 조회", e);
         }
     }
 }

--- a/src/main/java/com/jung/planet/r2/CloudflareR2Uploader.java
+++ b/src/main/java/com/jung/planet/r2/CloudflareR2Uploader.java
@@ -28,8 +28,8 @@ public class CloudflareR2Uploader {
     private static final Logger logger = LoggerFactory.getLogger(CloudflareR2Uploader.class);
 
 
-    private final CloudFlareR2Utils cloudFlareR2Utils;
-    private final CloudFlarePurgeCache cloudFlarePurgeCache;
+    private final CloudflareR2Utils cloudflareR2Utils;
+    private final CloudflarePurgeCache cloudflarePurgeCache;
 
     private final S3Client s3Client;
 
@@ -40,18 +40,18 @@ public class CloudflareR2Uploader {
 
     @Autowired
     public CloudflareR2Uploader(
-            CloudFlareR2Utils cloudFlareR2Utils,
-            CloudFlarePurgeCache cloudFlarePurgeCache,
+            CloudflareR2Utils cloudflareR2Utils,
+            CloudflarePurgeCache cloudflarePurgeCache,
             @Value("${cloudflareR2.access_id}") String access_id,
             @Value("${cloudflareR2.secret_key}") String secret_key,
             @Value("${cloudflareR2.end_point}") String end_point,
             @Value("${cloudflareR2.storage_point}") String storage_point,
             @Value("${cloudflareR2.bucket_name}") String bucket_name) {
-        this.cloudFlareR2Utils = cloudFlareR2Utils;
+        this.cloudflareR2Utils = cloudflareR2Utils;
         this.bucketName = bucket_name;
         this.endPointUri = end_point;
         this.storagePointUri = storage_point;
-        this.cloudFlarePurgeCache = cloudFlarePurgeCache;
+        this.cloudflarePurgeCache = cloudflarePurgeCache;
 
 
         AwsBasicCredentials awsCreds = AwsBasicCredentials.create(access_id, secret_key);
@@ -64,7 +64,7 @@ public class CloudflareR2Uploader {
     }
 
     public void uploadPlantImage(User user, Plant plant, ByteBuffer imageBuffer) {
-        String imageHash = cloudFlareR2Utils.calculateImageHash(imageBuffer);
+        String imageHash = cloudflareR2Utils.calculateImageHash(imageBuffer);
 
         String imageType = "thumbnail";
         String filePath = user.getEmail() + "/" + plant.getId()
@@ -83,7 +83,7 @@ public class CloudflareR2Uploader {
         String fileName = storagePointUri + filePath;
 
 
-        String imageHash = cloudFlareR2Utils.calculateImageHash(imageBuffer);
+        String imageHash = cloudflareR2Utils.calculateImageHash(imageBuffer);
 
         String existingImageHash = retrieveImageHashFromR2(filePath);
 
@@ -93,7 +93,7 @@ public class CloudflareR2Uploader {
 
             // 이미지 다르면 캐시 삭제
             uploadPlantImage(user, plant, imageBuffer);
-            cloudFlarePurgeCache.purgeCache(fileName);
+            cloudflarePurgeCache.purgeCache(fileName);
 
         }
     }
@@ -128,7 +128,7 @@ public class CloudflareR2Uploader {
 
     // Diary
     public void uploadDiaryImage(String userEmail, Diary diary, ByteBuffer imageBuffer) {
-        String imageHash = cloudFlareR2Utils.calculateImageHash(imageBuffer);
+        String imageHash = cloudflareR2Utils.calculateImageHash(imageBuffer);
         Plant plant = diary.getPlant();
 
         String imageType = "diary";
@@ -154,7 +154,7 @@ public class CloudflareR2Uploader {
         String fileName = storagePointUri + filePath;
 
 
-        String imageHash = cloudFlareR2Utils.calculateImageHash(imageBuffer);
+        String imageHash = cloudflareR2Utils.calculateImageHash(imageBuffer);
 
         String existingImageHash = retrieveImageHashFromR2(filePath);
 
@@ -162,7 +162,7 @@ public class CloudflareR2Uploader {
         if (!imageHash.equals(existingImageHash)) {
             // 이미지 다르면 캐시 삭제
             uploadDiaryImage(userEmail, diary, imageBuffer);
-            cloudFlarePurgeCache.purgeCache(fileName);
+            cloudflarePurgeCache.purgeCache(fileName);
 
         }
     }

--- a/src/main/java/com/jung/planet/r2/CloudflareR2Utils.java
+++ b/src/main/java/com/jung/planet/r2/CloudflareR2Utils.java
@@ -9,7 +9,7 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
 
 @Component
-public class CloudFlareR2Utils {
+public class CloudflareR2Utils {
 
     /**
      * 이미지 버퍼의 SHA-256 해시값을 계산합니다.

--- a/src/main/java/com/jung/planet/report/dto/ReportDTO.java
+++ b/src/main/java/com/jung/planet/report/dto/ReportDTO.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.Setter;
 
 @Getter
-@Setter
+@Builder
 public class ReportDTO {
     private Long reportId;
 

--- a/src/main/java/com/jung/planet/report/entity/Report.java
+++ b/src/main/java/com/jung/planet/report/entity/Report.java
@@ -3,14 +3,16 @@ package com.jung.planet.report.entity;
 import com.jung.planet.diary.entity.Diary;
 import com.jung.planet.plant.entity.Plant;
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.AllArgsConstructor;
 
 @Getter
-@Setter
 @Entity
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Table(name = "report")
 public class Report {
     @Id

--- a/src/main/java/com/jung/planet/report/repository/ReportRepository.java
+++ b/src/main/java/com/jung/planet/report/repository/ReportRepository.java
@@ -20,7 +20,7 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
             "JOIN FETCH r.reportedPlant p " +
             "JOIN FETCH p.user " +
             "WHERE r.reportedPlant IS NOT NULL")
-    List<Report> findAllPlantReportsWithUser();
+    List<Report> findPlantReportsWithUserFetchJoin();
 
     /**
      * N+1 문제 해결을 위해 fetch join을 사용하여 Diary, Plant, User를 함께 조회합니다.
@@ -30,6 +30,6 @@ public interface ReportRepository extends JpaRepository<Report, Long> {
             "JOIN FETCH d.plant p " +
             "JOIN FETCH p.user " +
             "WHERE r.reportedDiary IS NOT NULL")
-    List<Report> findAllDiaryReportsWithUser();
+    List<Report> findDiaryReportsWithUserFetchJoin();
 }
 

--- a/src/main/java/com/jung/planet/report/repository/ReportRepository.java
+++ b/src/main/java/com/jung/planet/report/repository/ReportRepository.java
@@ -3,6 +3,7 @@ package com.jung.planet.report.repository;
 import com.jung.planet.report.entity.Report;
 import com.jung.planet.report.entity.ReportType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -11,5 +12,24 @@ import java.util.List;
 public interface ReportRepository extends JpaRepository<Report, Long> {
     List<Report> findByReportedPlantIsNotNull();
     List<Report> findByReportedDiaryIsNotNull();
+
+    /**
+     * N+1 문제 해결을 위해 fetch join을 사용하여 Plant와 User를 함께 조회합니다.
+     */
+    @Query("SELECT r FROM Report r " +
+            "JOIN FETCH r.reportedPlant p " +
+            "JOIN FETCH p.user " +
+            "WHERE r.reportedPlant IS NOT NULL")
+    List<Report> findAllPlantReportsWithUser();
+
+    /**
+     * N+1 문제 해결을 위해 fetch join을 사용하여 Diary, Plant, User를 함께 조회합니다.
+     */
+    @Query("SELECT r FROM Report r " +
+            "JOIN FETCH r.reportedDiary d " +
+            "JOIN FETCH d.plant p " +
+            "JOIN FETCH p.user " +
+            "WHERE r.reportedDiary IS NOT NULL")
+    List<Report> findAllDiaryReportsWithUser();
 }
 

--- a/src/main/java/com/jung/planet/report/service/ReportService.java
+++ b/src/main/java/com/jung/planet/report/service/ReportService.java
@@ -39,11 +39,16 @@ public class ReportService {
 
     @Transactional
     public void reportEntity(Long entityId, ReportType entityType, Long reporterId) {
-        Report report = new Report();
+        Report report;
+
         if (entityType.equals(ReportType.PLANT)) {
             Plant plant = plantRepository.findById(entityId)
                     .orElseThrow(() -> new EntityNotFoundException("식물을 찾을 수 없습니다."));
-            report.setReportedPlant(plant);
+
+            report = Report.builder()
+                    .reportedPlant(plant)
+                    .reporterId(reporterId)
+                    .build();
 
             Map<String, String> infoData = new HashMap<>();
             infoData.put("PLANT ID", plant.getId().toString());
@@ -54,16 +59,20 @@ public class ReportService {
         } else if (entityType.equals(ReportType.DIARY)) {
             Diary diary = diaryRepository.findById(entityId)
                     .orElseThrow(() -> new EntityNotFoundException("일지를 찾을 수 없습니다."));
-            report.setReportedDiary(diary);
+
+            report = Report.builder()
+                    .reportedDiary(diary)
+                    .reporterId(reporterId)
+                    .build();
 
             Map<String, String> infoData = new HashMap<>();
             infoData.put("DIARY ID", diary.getId().toString());
             infoData.put("DIARY CONTENT", diary.getContent());
             infoData.put("DIARY IMG_URL", diary.getImgUrl());
             slackNotificationService.sendSlackReportNotification("다이어리 신고", infoData);
+        } else {
+            throw new IllegalArgumentException("지원하지 않는 신고 유형입니다.");
         }
-
-        report.setReporterId(reporterId);
 
         reportRepository.save(report);
     }

--- a/src/main/java/com/jung/planet/report/service/ReportService.java
+++ b/src/main/java/com/jung/planet/report/service/ReportService.java
@@ -18,6 +18,7 @@ import com.jung.planet.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.HashMap;
 import java.util.List;
@@ -36,6 +37,7 @@ public class ReportService {
     private final DiaryService diaryService;
     private final SlackNotificationService slackNotificationService;
 
+    @Transactional
     public void reportEntity(Long entityId, ReportType entityType, Long reporterId) {
         Report report = new Report();
         if (entityType.equals(ReportType.PLANT)) {
@@ -66,26 +68,27 @@ public class ReportService {
         reportRepository.save(report);
     }
 
-
+    @Transactional(readOnly = true)
     public List<ReportDTO> getAllDiaryReports() {
-        return reportRepository.findByReportedDiaryIsNotNull().stream()
+        return reportRepository.findAllDiaryReportsWithUser().stream()
                 .map(this::convertToDiaryReportDTO)
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public List<ReportDTO> getAllPlantReports() {
-        return reportRepository.findByReportedPlantIsNotNull().stream()
+        return reportRepository.findAllPlantReportsWithUser().stream()
                 .map(this::convertToPlantReportDTO)
                 .collect(Collectors.toList());
     }
 
 
     private ReportDTO convertToDiaryReportDTO(Report report) {
-        Diary diary = diaryRepository.findById(report.getId()).orElseThrow(() -> new EntityNotFoundException("다이어리 데이터를 찾을 수 없습니다."));
+        Diary diary = report.getReportedDiary();
         DiaryDetailDTO diaryDetailDTO = diaryService.findDiary(diary.getId(), 0L);
-        User reporter = userRepository.findById(report.getReporterId()).orElseThrow(() -> new EntityNotFoundException("유저 정보 없음"));
-        User diaryOwner = userRepository.findById(diary.getPlant().getUser().getId()).orElseThrow(() -> new EntityNotFoundException("유저 정보 없음"));
-
+        User reporter = userRepository.findById(report.getReporterId())
+                .orElseThrow(() -> new EntityNotFoundException("유저 정보 없음"));
+        User diaryOwner = diary.getPlant().getUser();
 
         return ReportDTO.builder()
                 .reportId(report.getId())
@@ -96,17 +99,18 @@ public class ReportService {
     }
 
     private ReportDTO convertToPlantReportDTO(Report report) {
-        Plant plant = plantRepository.findById(report.getId()).orElseThrow(() -> new EntityNotFoundException("식물 데이터를 찾을 수 없습니다."));
+        Plant plant = report.getReportedPlant();
         PlantDetailDTO plantDetailDTO = plantService.getPlantDetailsByPlantId(0L, plant.getId());
-        User reporter = userRepository.findById(report.getReporterId()).orElseThrow(() -> new EntityNotFoundException("유저 정보 없음"));
-        User plantOwner = userRepository.findById(plant.getUser().getId()).orElseThrow(() -> new EntityNotFoundException("유저 정보 없음"));
+        User reporter = userRepository.findById(report.getReporterId())
+                .orElseThrow(() -> new EntityNotFoundException("유저 정보 없음"));
+        User plantOwner = plant.getUser();
 
-
-        return ReportDTO.builder().reportId(report.getId())
+        return ReportDTO.builder()
+                .reportId(report.getId())
                 .reporterId(reporter.getEmail())
                 .entityOwnerId(plantOwner.getEmail())
-                .plantDetails(plantDetailDTO).build();
-
+                .plantDetails(plantDetailDTO)
+                .build();
     }
 
 

--- a/src/main/java/com/jung/planet/report/service/ReportService.java
+++ b/src/main/java/com/jung/planet/report/service/ReportService.java
@@ -79,14 +79,14 @@ public class ReportService {
 
     @Transactional(readOnly = true)
     public List<ReportDTO> getAllDiaryReports() {
-        return reportRepository.findAllDiaryReportsWithUser().stream()
+        return reportRepository.findDiaryReportsWithUserFetchJoin().stream()
                 .map(this::convertToDiaryReportDTO)
                 .collect(Collectors.toList());
     }
 
     @Transactional(readOnly = true)
     public List<ReportDTO> getAllPlantReports() {
-        return reportRepository.findAllPlantReportsWithUser().stream()
+        return reportRepository.findPlantReportsWithUserFetchJoin().stream()
                 .map(this::convertToPlantReportDTO)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/com/jung/planet/security/JwtTokenProvider.java
+++ b/src/main/java/com/jung/planet/security/JwtTokenProvider.java
@@ -30,11 +30,15 @@ public class JwtTokenProvider {
 
     private static final Logger logger = LoggerFactory.getLogger(JwtTokenProvider.class);
     private final Key key;
+    private final long validityInMilliseconds;
+    private final long refreshTokenValidityInMilliseconds;
 
-    private final long validityInMilliseconds = 1000 * 60 * 60 * 12; // 12h
-    private final long refreshTokenValidityInMilliseconds = 1000 * 60 * 60 * 24 * 7; // 1 week
-
-    public JwtTokenProvider(@Value("${jwt.secret}") String secretKey) {
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secretKey,
+            @Value("${jwt.access-token-validity}") long accessTokenValidity,
+            @Value("${jwt.refresh-token-validity}") long refreshTokenValidity) {
+        this.validityInMilliseconds = accessTokenValidity;
+        this.refreshTokenValidityInMilliseconds = refreshTokenValidity;
         try {
             byte[] keyBytes = Decoders.BASE64.decode(secretKey);
             this.key = Keys.hmacShaKeyFor(keyBytes);

--- a/src/main/java/com/jung/planet/security/UserDetail/CustomUserDetails.java
+++ b/src/main/java/com/jung/planet/security/UserDetail/CustomUserDetails.java
@@ -3,7 +3,6 @@ package com.jung.planet.security.UserDetail;
 
 import com.jung.planet.user.entity.UserRole;
 import lombok.Getter;
-import lombok.Setter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
@@ -11,7 +10,6 @@ import java.util.Collection;
 import java.util.Collections;
 
 @Getter
-@Setter
 public class CustomUserDetails implements UserDetails {
 
     private final Long userId;
@@ -19,7 +17,7 @@ public class CustomUserDetails implements UserDetails {
     private final UserRole userRole;
     private final String password = "";
 
-    private Collection<? extends GrantedAuthority> authorities;
+    private final Collection<? extends GrantedAuthority> authorities;
 
 
     public CustomUserDetails(Long userId, String username, UserRole userRole, Collection<? extends GrantedAuthority> authorities) {

--- a/src/main/java/com/jung/planet/security/UserDetail/CustomUserDetailsService.java
+++ b/src/main/java/com/jung/planet/security/UserDetail/CustomUserDetailsService.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
 
@@ -20,6 +21,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
+    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByEmail(username)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + username));

--- a/src/main/java/com/jung/planet/user/controller/UserController.java
+++ b/src/main/java/com/jung/planet/user/controller/UserController.java
@@ -1,8 +1,6 @@
 package com.jung.planet.user.controller;
 
 import com.jung.planet.common.dto.ApiResponseDTO;
-import com.jung.planet.plant.repository.UserPlantHeartRepository;
-import com.jung.planet.plant.service.PlantService;
 import com.jung.planet.security.JwtTokenProvider;
 import com.jung.planet.security.UserDetail.CustomUserDetails;
 import com.jung.planet.user.dto.JwtResponse;
@@ -10,7 +8,6 @@ import com.jung.planet.user.dto.UserDTO;
 import com.jung.planet.user.dto.response.TokenResponseDTO;
 import com.jung.planet.user.dto.response.UserResponseDTO;
 import com.jung.planet.user.entity.User;
-import com.jung.planet.user.repository.UserRepository;
 import com.jung.planet.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,20 +16,10 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 
 @Tag(name = "User", description = "사용자 관련 API")
 @RestController
@@ -40,12 +27,7 @@ import java.util.Optional;
 @RequestMapping("/users")
 @Slf4j
 public class UserController {
-    private final UserRepository userRepository;
-    private static final Logger logger = LoggerFactory.getLogger(UserController.class);
-
     private final UserService userService;
-    private final PlantService plantService;
-    private final UserPlantHeartRepository userPlantHeartRepository;
     private final JwtTokenProvider jwtTokenProvider;
 
     @Operation(summary = "사용자 로그인", description = "사용자 계정으로 로그인합니다.")
@@ -57,7 +39,7 @@ public class UserController {
     })
     @PostMapping("/login")
     public ApiResponseDTO<JwtResponse> getCurrentUser(@RequestBody UserDTO userDTO) {
-        logger.debug("USER LOGIN :: {} ", userDTO);
+        log.debug("USER LOGIN :: {} ", userDTO);
         User user = userService.processUser(userDTO);
         String access_token = jwtTokenProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole());
 
@@ -85,20 +67,9 @@ public class UserController {
     })
     @PostMapping("/refresh")
     public ApiResponseDTO<TokenResponseDTO> refreshTokens(@RequestParam String refreshToken) {
-        String email = jwtTokenProvider.decodeJwt(refreshToken).getSubject();
-        Optional<User> user = userService.findByEmail(email);
+        TokenResponseDTO tokenResponse = userService.refreshUserTokens(refreshToken);
 
-        if (user.isPresent() && user.get().getRefreshToken().equals(refreshToken) && jwtTokenProvider.validateToken(refreshToken)) {
-            String newAccessToken = jwtTokenProvider.createAccessToken(user.get().getId(), user.get().getEmail(), user.get().getRole());
-            String newRefreshToken = jwtTokenProvider.createRefreshToken(user.get().getId(), user.get().getEmail(), user.get().getRole());
-
-            userService.updateRefreshToken(user.get().getId(), newRefreshToken);
-
-            TokenResponseDTO tokenResponse = TokenResponseDTO.builder()
-                    .access_token(newAccessToken)
-                    .refresh_token(newRefreshToken)
-                    .build();
-                    
+        if (tokenResponse != null) {
             return ApiResponseDTO.success(tokenResponse, "토큰이 성공적으로 갱신되었습니다.");
         } else {
             return ApiResponseDTO.error("유효하지 않은 리프레시 토큰입니다.", TokenResponseDTO.builder().build());
@@ -115,23 +86,7 @@ public class UserController {
     @GetMapping("/my-info")
     public ApiResponseDTO<UserResponseDTO> getMyInfo(@AuthenticationPrincipal CustomUserDetails customUserDetails) {
         Long userId = customUserDetails.getUserId();
-        User user = userRepository.findById(userId).orElseThrow(() -> new EntityNotFoundException("해당하는 유저를 찾을 수 없습니다."));
-
-        int totalHeartsGivenByUser = userPlantHeartRepository.countByUserId(userId);
-        int totalHearts = plantService.getTotalHearts(userId);
-        long daysSinceCreated = ChronoUnit.DAYS.between(user.getCreatedAt(), LocalDateTime.now());
-        int maxPlants = user.getSubscription().getMaxPlants();
-        boolean aiServiceAccess = user.getSubscription().isAiServiceAccess();
-
-        UserResponseDTO userResponse = UserResponseDTO.builder()
-                .name(user.getName())
-                .period(daysSinceCreated)
-                .receivedHearts(totalHearts)
-                .givenHearts(totalHeartsGivenByUser)
-                .maxPlants(maxPlants)
-                .aiServiceAccess(aiServiceAccess)
-                .build();
-
+        UserResponseDTO userResponse = userService.getUserInfo(userId);
         return ApiResponseDTO.success(userResponse);
     }
 }

--- a/src/main/java/com/jung/planet/user/dto/JwtResponse.java
+++ b/src/main/java/com/jung/planet/user/dto/JwtResponse.java
@@ -1,20 +1,16 @@
 package com.jung.planet.user.dto;
 
 import com.jung.planet.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
+@Builder
+@AllArgsConstructor
 public class JwtResponse {
     private String access_token;
     private String refresh_token;
     private User user;
-
-    public JwtResponse(String access_token,String refresh_token, User user) {
-        this.access_token = access_token;
-        this.refresh_token = refresh_token;
-        this.user = user;
-    }
 }
 

--- a/src/main/java/com/jung/planet/user/entity/Subscription.java
+++ b/src/main/java/com/jung/planet/user/entity/Subscription.java
@@ -5,12 +5,10 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 import java.time.LocalDate;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @Entity
 @Table(name = "subscription")
@@ -39,6 +37,28 @@ public class Subscription {
     @OneToOne
     @JoinColumn(name = "user_id", referencedColumnName = "id")
     private User user;
+
+    /**
+     * User와의 양방향 관계를 설정합니다.
+     */
+    public void assignUser(User user) {
+        if (user == null) {
+            throw new IllegalArgumentException("사용자는 null일 수 없습니다.");
+        }
+        this.user = user;
+    }
+
+    /**
+     * 구독 타입을 업그레이드합니다.
+     */
+    public void upgradeToType(SubscriptionType newType) {
+        if (newType == null) {
+            throw new IllegalArgumentException("구독 타입은 null일 수 없습니다.");
+        }
+        this.type = newType;
+        this.maxPlants = newType.getMaxPlants();
+        this.aiServiceAccess = newType.isAiServiceAccess();
+    }
 
     // 구독 시작
     public void startSubscription() {

--- a/src/main/java/com/jung/planet/user/entity/SubscriptionType.java
+++ b/src/main/java/com/jung/planet/user/entity/SubscriptionType.java
@@ -1,5 +1,17 @@
 package com.jung.planet.user.entity;
 
+import lombok.Getter;
+
+@Getter
 public enum SubscriptionType {
-    BASIC, PREMIUM
+    BASIC(3, false),
+    PREMIUM(6, true);
+
+    private final int maxPlants;
+    private final boolean aiServiceAccess;
+
+    SubscriptionType(int maxPlants, boolean aiServiceAccess) {
+        this.maxPlants = maxPlants;
+        this.aiServiceAccess = aiServiceAccess;
+    }
 }

--- a/src/main/java/com/jung/planet/user/entity/User.java
+++ b/src/main/java/com/jung/planet/user/entity/User.java
@@ -37,7 +37,6 @@ public class User {
     @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
     private Subscription subscription;
 
-
     @JsonIgnore
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<Plant> plants;
@@ -45,26 +44,48 @@ public class User {
     @Enumerated(EnumType.STRING)
     private UserRole role;
 
-
-    public void setRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
+    /**
+     * 리프레시 토큰을 업데이트합니다.
+     *
+     * @param newRefreshToken 새로운 리프레시 토큰
+     * @throws IllegalArgumentException 토큰이 null이거나 비어있는 경우
+     */
+    public void updateRefreshToken(String newRefreshToken) {
+        if (newRefreshToken == null || newRefreshToken.isBlank()) {
+            throw new IllegalArgumentException("리프레시 토큰은 null이거나 비어있을 수 없습니다.");
+        }
+        this.refreshToken = newRefreshToken;
     }
 
-    public void setRole(UserRole role) {
+    /**
+     * 리프레시 토큰을 초기화합니다.
+     * 로그아웃 시 사용됩니다.
+     */
+    public void clearRefreshToken() {
+        this.refreshToken = null;
+    }
+
+    /**
+     * 사용자 역할을 설정합니다.
+     *
+     * @param role 사용자 역할
+     * @throws IllegalArgumentException 역할이 null인 경우
+     */
+    public void assignRole(UserRole role) {
+        if (role == null) {
+            throw new IllegalArgumentException("사용자 역할은 null일 수 없습니다.");
+        }
         this.role = role;
     }
 
-
-
-
-
-
-
-
-    public void setSubscription(Subscription subscription) {
+    /**
+     * 구독 정보를 설정합니다.
+     *
+     * @param subscription 구독 정보
+     */
+    public void attachSubscription(Subscription subscription) {
         this.subscription = subscription;
     }
-  
 
     @Builder(toBuilder = true)
     public User(String email, String name, String refreshToken, Subscription subscription) {

--- a/src/main/java/com/jung/planet/user/service/UserService.java
+++ b/src/main/java/com/jung/planet/user/service/UserService.java
@@ -4,11 +4,14 @@ package com.jung.planet.user.service;
 import com.jung.planet.admin.service.SlackNotificationService;
 
 import com.jung.planet.exception.UnauthorizedActionException;
+import com.jung.planet.plant.repository.PlantRepository;
 import com.jung.planet.plant.repository.UserPlantHeartRepository;
 import com.jung.planet.r2.CloudflareR2Uploader;
 import com.jung.planet.security.JwtTokenProvider;
 import com.jung.planet.security.UserDetail.CustomUserDetails;
 import com.jung.planet.user.dto.UserDTO;
+import com.jung.planet.user.dto.response.TokenResponseDTO;
+import com.jung.planet.user.dto.response.UserResponseDTO;
 import com.jung.planet.user.entity.Subscription;
 import com.jung.planet.user.entity.SubscriptionType;
 import com.jung.planet.user.entity.User;
@@ -21,6 +24,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -32,9 +37,8 @@ public class UserService {
     private final JwtTokenProvider jwtTokenProvider;
     private final CloudflareR2Uploader cloudflareR2Uploader;
     private final UserPlantHeartRepository userPlantHeartRepository;
-
+    private final PlantRepository plantRepository;
     private final SlackNotificationService slackNotificationService;
-
 
     private static final Logger logger = LoggerFactory.getLogger(UserService.class);
 
@@ -172,6 +176,71 @@ public class UserService {
 
     public Optional<User> findByEmail(String email) {
         return userRepository.findByEmail(email);
+    }
+
+    /**
+     * 리프레시 토큰을 검증하고 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.
+     *
+     * @param refreshToken 리프레시 토큰
+     * @return 새로운 토큰 정보 또는 null (유효하지 않은 경우)
+     */
+    @Transactional
+    public TokenResponseDTO refreshUserTokens(String refreshToken) {
+        String email = jwtTokenProvider.decodeJwt(refreshToken).getSubject();
+        Optional<User> userOptional = userRepository.findByEmail(email);
+
+        if (userOptional.isEmpty()) {
+            return null;
+        }
+
+        User user = userOptional.get();
+
+        // 토큰 검증: DB에 저장된 리프레시 토큰과 일치하고, 유효한 토큰인지 확인
+        if (!user.getRefreshToken().equals(refreshToken) || !jwtTokenProvider.validateToken(refreshToken)) {
+            return null;
+        }
+
+        // 새로운 토큰 생성
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getId(), user.getEmail(), user.getRole());
+        String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId(), user.getEmail(), user.getRole());
+
+        // 새로운 리프레시 토큰 저장
+        user.setRefreshToken(newRefreshToken);
+        userRepository.save(user);
+
+        return TokenResponseDTO.builder()
+                .access_token(newAccessToken)
+                .refresh_token(newRefreshToken)
+                .build();
+    }
+
+    /**
+     * 사용자 정보를 조회합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 사용자 상세 정보
+     */
+    @Transactional(readOnly = true)
+    public UserResponseDTO getUserInfo(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("해당하는 유저를 찾을 수 없습니다."));
+
+        int totalHeartsGivenByUser = userPlantHeartRepository.countByUserId(userId);
+        Integer totalHearts = plantRepository.sumHeartsByUserId(userId);
+        int receivedHearts = totalHearts != null ? totalHearts : 0;
+
+        long daysSinceCreated = ChronoUnit.DAYS.between(user.getCreatedAt(), LocalDateTime.now());
+        int maxPlants = user.getSubscription().getMaxPlants();
+        boolean aiServiceAccess = user.getSubscription().isAiServiceAccess();
+
+        return UserResponseDTO.builder()
+                .name(user.getName())
+                .period(daysSinceCreated)
+                .receivedHearts(receivedHearts)
+                .givenHearts(totalHeartsGivenByUser)
+                .maxPlants(maxPlants)
+                .aiServiceAccess(aiServiceAccess)
+                .build();
     }
 
 

--- a/src/main/java/com/jung/planet/user/service/UserService.java
+++ b/src/main/java/com/jung/planet/user/service/UserService.java
@@ -121,13 +121,10 @@ public class UserService {
         User userToDelete = userRepository.findById(customUserDetails.getUserId())
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
-        if (customUserDetails.getUserRole().equals(UserRole.ADMIN) || userToDelete != null) {
-            userPlantHeartRepository.deleteByUserId(customUserDetails.getUserId());
-            userRepository.deleteById(customUserDetails.getUserId());
-            cloudflareR2Uploader.deleteUser(userToDelete.getEmail());
-        } else {
-            throw new UnauthorizedActionException("삭제 권한이 없습니다.");
-        }
+        // 사용자는 자신의 계정을 삭제할 수 있음 (Admin이 아니어도 가능)
+        userPlantHeartRepository.deleteByUserId(customUserDetails.getUserId());
+        userRepository.deleteById(customUserDetails.getUserId());
+        cloudflareR2Uploader.deleteUser(userToDelete.getEmail());
     }
 
     @Transactional

--- a/src/main/java/com/jung/planet/user/service/UserService.java
+++ b/src/main/java/com/jung/planet/user/service/UserService.java
@@ -48,80 +48,71 @@ public class UserService {
         Optional<User> user = userRepository.findByEmail(userDTO.getEmail());
 
         if (user.isEmpty()) {
-            Subscription subscription = Subscription.builder()
-                    .type(SubscriptionType.PREMIUM)
-                    .maxPlants(6)
-                    .aiServiceAccess(true)
-                    .build();
-
-            User newUser = User.builder()
-                    .email(userDTO.getEmail())
-                    .name(userDTO.getName())
-                    .subscription(subscription)
-                    .build();
-
-            subscription.setUser(newUser);
-
-            newUser.setRole(UserRole.ADMIN);
-
-            String refreshToken = jwtTokenProvider.createRefreshToken(newUser.getId(), newUser.getEmail(), newUser.getRole());
-            newUser.setRefreshToken(refreshToken);
-
-            userRepository.save(newUser);
-
+            User newUser = createNewUser(userDTO, SubscriptionType.PREMIUM, UserRole.ADMIN);
 
             Map<String, String> infoData = new HashMap<>();
             infoData.put("Email", newUser.getEmail());
-
             slackNotificationService.sendSlackOkNotification("어드민 유저 생성 ", infoData);
 
             return newUser;
         } else {
-            User existingUser = user.get();
-            String refreshToken = jwtTokenProvider.createRefreshToken(existingUser.getId(), existingUser.getEmail(), existingUser.getRole());
-            existingUser.setRefreshToken(refreshToken);
-            userRepository.save(existingUser);
-
-            return existingUser;
+            return updateRefreshTokenForExistingUser(user.get());
         }
     }
-
 
     @Transactional
     public User processUser(UserDTO userDTO) {
         Optional<User> user = userRepository.findByEmail(userDTO.getEmail());
 
-        // 사용자가 존재하지 않으면 새로운 사용자를 생성
         if (user.isEmpty()) {
-            Subscription subscription = Subscription.builder()
-                    .type(SubscriptionType.BASIC)
-                    .maxPlants(3)
-                    .aiServiceAccess(false)
-                    .build();
-
-            User newUser = User.builder()
-                    .email(userDTO.getEmail())
-                    .name(userDTO.getName())
-                    .subscription(subscription)
-                    .build();
-
-            subscription.setUser(newUser);
-            newUser.setRole(UserRole.NORMAL);
-
-
-            String refreshToken = jwtTokenProvider.createRefreshToken(newUser.getId(), newUser.getEmail(), newUser.getRole());
-            newUser.setRefreshToken(refreshToken);
-
-            userRepository.save(newUser);
-            return newUser;
+            return createNewUser(userDTO, SubscriptionType.BASIC, UserRole.NORMAL);
         } else {
-            User existingUser = user.get();
-            String refreshToken = jwtTokenProvider.createRefreshToken(existingUser.getId(), existingUser.getEmail(), existingUser.getRole());
-            existingUser.setRefreshToken(refreshToken);
-            userRepository.save(existingUser);
-
-            return existingUser;
+            return updateRefreshTokenForExistingUser(user.get());
         }
+    }
+
+    /**
+     * 새로운 사용자를 생성합니다.
+     *
+     * @param userDTO 사용자 정보
+     * @param subscriptionType 구독 타입
+     * @param userRole 사용자 역할
+     * @return 생성된 사용자
+     */
+    private User createNewUser(UserDTO userDTO, SubscriptionType subscriptionType, UserRole userRole) {
+        Subscription subscription = Subscription.builder()
+                .type(subscriptionType)
+                .maxPlants(subscriptionType.getMaxPlants())
+                .aiServiceAccess(subscriptionType.isAiServiceAccess())
+                .build();
+
+        User newUser = User.builder()
+                .email(userDTO.getEmail())
+                .name(userDTO.getName())
+                .subscription(subscription)
+                .build();
+
+        subscription.setUser(newUser);
+        newUser.setRole(userRole);
+
+        String refreshToken = jwtTokenProvider.createRefreshToken(newUser.getId(), newUser.getEmail(), newUser.getRole());
+        newUser.setRefreshToken(refreshToken);
+
+        userRepository.save(newUser);
+        return newUser;
+    }
+
+    /**
+     * 기존 사용자의 리프레시 토큰을 갱신합니다.
+     *
+     * @param user 기존 사용자
+     * @return 토큰이 갱신된 사용자
+     */
+    private User updateRefreshTokenForExistingUser(User user) {
+        String refreshToken = jwtTokenProvider.createRefreshToken(user.getId(), user.getEmail(), user.getRole());
+        user.setRefreshToken(refreshToken);
+        userRepository.save(user);
+        return user;
     }
 
 
@@ -144,10 +135,11 @@ public class UserService {
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다."));
 
+        SubscriptionType subscriptionType = SubscriptionType.PREMIUM;
         Subscription subscription = user.getSubscription();
-        subscription.setType(SubscriptionType.PREMIUM);
-        subscription.setMaxPlants(6);
-        subscription.setAiServiceAccess(true);
+        subscription.setType(subscriptionType);
+        subscription.setMaxPlants(subscriptionType.getMaxPlants());
+        subscription.setAiServiceAccess(subscriptionType.isAiServiceAccess());
         subscription.startSubscription();
 
 

--- a/src/main/java/com/jung/planet/user/service/UserService.java
+++ b/src/main/java/com/jung/planet/user/service/UserService.java
@@ -160,6 +160,7 @@ public class UserService {
         });
     }
 
+    @Transactional(readOnly = true)
     public Optional<User> findByEmail(String email) {
         return userRepository.findByEmail(email);
     }
@@ -212,7 +213,7 @@ public class UserService {
                 .orElseThrow(() -> new EntityNotFoundException("해당하는 유저를 찾을 수 없습니다."));
 
         int totalHeartsGivenByUser = userPlantHeartRepository.countByUserId(userId);
-        Integer totalHearts = plantRepository.sumHeartsByUserId(userId);
+        Integer totalHearts = plantRepository.sumHeartCountByUserId(userId);
         int receivedHearts = totalHearts != null ? totalHearts : 0;
 
         long daysSinceCreated = ChronoUnit.DAYS.between(user.getCreatedAt(), LocalDateTime.now());

--- a/src/main/java/com/jung/planet/user/service/UserService.java
+++ b/src/main/java/com/jung/planet/user/service/UserService.java
@@ -92,7 +92,7 @@ public class UserService {
                 .subscription(subscription)
                 .build();
 
-        subscription.setUser(newUser);
+        subscription.assignUser(newUser);
         newUser.assignRole(userRole);
 
         String refreshToken = jwtTokenProvider.createRefreshToken(newUser.getId(), newUser.getEmail(), newUser.getRole());
@@ -134,9 +134,7 @@ public class UserService {
 
         SubscriptionType subscriptionType = SubscriptionType.PREMIUM;
         Subscription subscription = user.getSubscription();
-        subscription.setType(subscriptionType);
-        subscription.setMaxPlants(subscriptionType.getMaxPlants());
-        subscription.setAiServiceAccess(subscriptionType.isAiServiceAccess());
+        subscription.upgradeToType(subscriptionType);
         subscription.startSubscription();
 
         user.attachSubscription(subscription);

--- a/src/main/java/com/jung/planet/user/service/UserService.java
+++ b/src/main/java/com/jung/planet/user/service/UserService.java
@@ -93,10 +93,10 @@ public class UserService {
                 .build();
 
         subscription.setUser(newUser);
-        newUser.setRole(userRole);
+        newUser.assignRole(userRole);
 
         String refreshToken = jwtTokenProvider.createRefreshToken(newUser.getId(), newUser.getEmail(), newUser.getRole());
-        newUser.setRefreshToken(refreshToken);
+        newUser.updateRefreshToken(refreshToken);
 
         userRepository.save(newUser);
         return newUser;
@@ -110,7 +110,7 @@ public class UserService {
      */
     private User updateRefreshTokenForExistingUser(User user) {
         String refreshToken = jwtTokenProvider.createRefreshToken(user.getId(), user.getEmail(), user.getRole());
-        user.setRefreshToken(refreshToken);
+        user.updateRefreshToken(refreshToken);
         userRepository.save(user);
         return user;
     }
@@ -139,8 +139,7 @@ public class UserService {
         subscription.setAiServiceAccess(subscriptionType.isAiServiceAccess());
         subscription.startSubscription();
 
-
-        user.setSubscription(subscription);
+        user.attachSubscription(subscription);
 
         userRepository.save(user);
 
@@ -158,7 +157,7 @@ public class UserService {
     public void updateRefreshToken(Long userId, String refreshToken) {
         Optional<User> user = userRepository.findById(userId);
         user.ifPresent(u -> {
-            u.setRefreshToken(refreshToken);
+            u.updateRefreshToken(refreshToken);
             userRepository.save(u);
         });
     }
@@ -194,7 +193,7 @@ public class UserService {
         String newRefreshToken = jwtTokenProvider.createRefreshToken(user.getId(), user.getEmail(), user.getRole());
 
         // 새로운 리프레시 토큰 저장
-        user.setRefreshToken(newRefreshToken);
+        user.updateRefreshToken(newRefreshToken);
         userRepository.save(user);
 
         return TokenResponseDTO.builder()

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,3 +13,8 @@ spring.jpa.properties.hibernate.format_sql=true
 
 # ?? ??
 spring.sql.init.platform=mysql
+
+# JWT
+jwt.secret=yourBase64EncodedSecretKeyHereAtLeast256BitsLongForHS256Algorithm
+jwt.access-token-validity=43200000
+jwt.refresh-token-validity=604800000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,8 @@ spring.jpa.properties.hibernate.format_sql=true
 spring.sql.init.platform=mysql
 
 # JWT
-jwt.secret=yourBase64EncodedSecretKeyHereAtLeast256BitsLongForHS256Algorithm
+# IMPORTANT: For production, use environment variables or external configuration
+# Generate a secure key: openssl rand -base64 64
+jwt.secret=YourSecureBase64EncodedSecretKeyForLocalDevelopmentOnlyPleaseChangeThisInProductionEnvironmentWithAtLeast256BitsKey==
 jwt.access-token-validity=43200000
 jwt.refresh-token-validity=604800000

--- a/src/test/java/com/jung/planet/admin/mapper/AdminMapperTest.java
+++ b/src/test/java/com/jung/planet/admin/mapper/AdminMapperTest.java
@@ -1,0 +1,122 @@
+package com.jung.planet.admin.mapper;
+
+import com.jung.planet.admin.dto.PremiumUserDTO;
+import com.jung.planet.user.entity.Subscription;
+import com.jung.planet.user.entity.SubscriptionType;
+import com.jung.planet.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AdminMapperTest {
+
+    private AdminMapper adminMapper;
+    private User user;
+    private Subscription subscription;
+
+    @BeforeEach
+    void setUp() {
+        adminMapper = new AdminMapper();
+
+        subscription = Subscription.builder()
+                .id(1L)
+                .type(SubscriptionType.PREMIUM)
+                .startDate(LocalDateTime.now().minusMonths(1))
+                .endDate(LocalDateTime.now().plusMonths(11))
+                .build();
+
+        user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .name("Test User")
+                .subscription(subscription)
+                .build();
+    }
+
+    @Test
+    @DisplayName("User를 PremiumUserDTO로 변환 - 성공")
+    void testToPremiumUserDto_Success() {
+        // When
+        PremiumUserDTO result = adminMapper.toPremiumUserDto(user);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("test@example.com", result.getEmail());
+        assertEquals("Test User", result.getName());
+        assertEquals(subscription, result.getSubscription());
+    }
+
+    @Test
+    @DisplayName("User를 PremiumUserDTO로 변환 - 모든 필드 매핑 확인")
+    void testToPremiumUserDto_AllFieldsMapped() {
+        // When
+        PremiumUserDTO result = adminMapper.toPremiumUserDto(user);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(user.getEmail(), result.getEmail());
+        assertEquals(user.getName(), result.getName());
+        assertEquals(user.getSubscription(), result.getSubscription());
+    }
+
+    @Test
+    @DisplayName("User를 PremiumUserDTO로 변환 - subscription이 null인 경우")
+    void testToPremiumUserDto_NullSubscription() {
+        // Given
+        User userWithoutSubscription = User.builder()
+                .id(2L)
+                .email("nosubscription@example.com")
+                .name("No Subscription User")
+                .subscription(null)
+                .build();
+
+        // When
+        PremiumUserDTO result = adminMapper.toPremiumUserDto(userWithoutSubscription);
+
+        // Then
+        assertNotNull(result);
+        assertEquals("nosubscription@example.com", result.getEmail());
+        assertEquals("No Subscription User", result.getName());
+        assertNull(result.getSubscription());
+    }
+
+    @Test
+    @DisplayName("User를 PremiumUserDTO로 변환 - 여러 사용자 변환")
+    void testToPremiumUserDto_MultipleUsers() {
+        // Given
+        User user1 = User.builder()
+                .id(1L)
+                .email("user1@example.com")
+                .name("User 1")
+                .subscription(subscription)
+                .build();
+
+        User user2 = User.builder()
+                .id(2L)
+                .email("user2@example.com")
+                .name("User 2")
+                .subscription(subscription)
+                .build();
+
+        // When
+        PremiumUserDTO result1 = adminMapper.toPremiumUserDto(user1);
+        PremiumUserDTO result2 = adminMapper.toPremiumUserDto(user2);
+
+        // Then
+        assertNotNull(result1);
+        assertNotNull(result2);
+
+        assertEquals("user1@example.com", result1.getEmail());
+        assertEquals("User 1", result1.getName());
+
+        assertEquals("user2@example.com", result2.getEmail());
+        assertEquals("User 2", result2.getName());
+
+        // 각각 독립적인 DTO 객체인지 확인
+        assertNotSame(result1, result2);
+    }
+}

--- a/src/test/java/com/jung/planet/admin/service/AdminServiceTest.java
+++ b/src/test/java/com/jung/planet/admin/service/AdminServiceTest.java
@@ -1,0 +1,210 @@
+package com.jung.planet.admin.service;
+
+import com.jung.planet.admin.dto.PremiumUserDTO;
+import com.jung.planet.admin.mapper.AdminMapper;
+import com.jung.planet.user.entity.Subscription;
+import com.jung.planet.user.entity.SubscriptionType;
+import com.jung.planet.user.entity.User;
+import com.jung.planet.user.repository.SubscriptionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock
+    private SubscriptionRepository subscriptionRepository;
+
+    @Mock
+    private AdminMapper adminMapper;
+
+    @InjectMocks
+    private AdminService adminService;
+
+    private User premiumUser1;
+    private User premiumUser2;
+    private Subscription subscription1;
+    private Subscription subscription2;
+    private PremiumUserDTO premiumUserDTO1;
+    private PremiumUserDTO premiumUserDTO2;
+
+    @BeforeEach
+    void setUp() {
+        premiumUser1 = User.builder()
+                .id(1L)
+                .email("premium1@example.com")
+                .name("Premium User 1")
+                .build();
+
+        premiumUser2 = User.builder()
+                .id(2L)
+                .email("premium2@example.com")
+                .name("Premium User 2")
+                .build();
+
+        subscription1 = Subscription.builder()
+                .id(1L)
+                .user(premiumUser1)
+                .type(SubscriptionType.PREMIUM)
+                .startDate(LocalDateTime.now().minusMonths(1))
+                .endDate(LocalDateTime.now().plusMonths(11))
+                .build();
+
+        subscription2 = Subscription.builder()
+                .id(2L)
+                .user(premiumUser2)
+                .type(SubscriptionType.PREMIUM)
+                .startDate(LocalDateTime.now().minusMonths(2))
+                .endDate(LocalDateTime.now().plusMonths(10))
+                .build();
+
+        premiumUserDTO1 = new PremiumUserDTO();
+        premiumUserDTO1.setEmail("premium1@example.com");
+        premiumUserDTO1.setName("Premium User 1");
+        premiumUserDTO1.setSubscription(subscription1);
+
+        premiumUserDTO2 = new PremiumUserDTO();
+        premiumUserDTO2.setEmail("premium2@example.com");
+        premiumUserDTO2.setName("Premium User 2");
+        premiumUserDTO2.setSubscription(subscription2);
+    }
+
+    @Test
+    @DisplayName("모든 프리미엄 사용자 조회 - 성공")
+    void testGetAllPremiumUsers_Success() {
+        // Given
+        List<Subscription> subscriptions = Arrays.asList(subscription1, subscription2);
+
+        when(subscriptionRepository.findByType(SubscriptionType.PREMIUM)).thenReturn(subscriptions);
+        when(adminMapper.toPremiumUserDto(premiumUser1)).thenReturn(premiumUserDTO1);
+        when(adminMapper.toPremiumUserDto(premiumUser2)).thenReturn(premiumUserDTO2);
+
+        // When
+        List<PremiumUserDTO> result = adminService.getAllPremiumUsers();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        assertEquals("premium1@example.com", result.get(0).getEmail());
+        assertEquals("premium2@example.com", result.get(1).getEmail());
+
+        verify(subscriptionRepository).findByType(SubscriptionType.PREMIUM);
+        verify(adminMapper).toPremiumUserDto(premiumUser1);
+        verify(adminMapper).toPremiumUserDto(premiumUser2);
+    }
+
+    @Test
+    @DisplayName("모든 프리미엄 사용자 조회 - 프리미엄 사용자 없음")
+    void testGetAllPremiumUsers_EmptyList() {
+        // Given
+        when(subscriptionRepository.findByType(SubscriptionType.PREMIUM)).thenReturn(Collections.emptyList());
+
+        // When
+        List<PremiumUserDTO> result = adminService.getAllPremiumUsers();
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+
+        verify(subscriptionRepository).findByType(SubscriptionType.PREMIUM);
+        verify(adminMapper, never()).toPremiumUserDto(any(User.class));
+    }
+
+    @Test
+    @DisplayName("모든 프리미엄 사용자 조회 - AdminMapper 사용 확인")
+    void testGetAllPremiumUsers_UsesAdminMapper() {
+        // Given
+        List<Subscription> subscriptions = Arrays.asList(subscription1);
+
+        when(subscriptionRepository.findByType(SubscriptionType.PREMIUM)).thenReturn(subscriptions);
+        when(adminMapper.toPremiumUserDto(premiumUser1)).thenReturn(premiumUserDTO1);
+
+        // When
+        List<PremiumUserDTO> result = adminService.getAllPremiumUsers();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+
+        // AdminMapper가 정확히 한 번 호출되었는지 확인 (DTO 변환 로직이 Mapper로 분리된 것 확인)
+        verify(adminMapper, times(1)).toPremiumUserDto(premiumUser1);
+    }
+
+    @Test
+    @DisplayName("모든 프리미엄 사용자 조회 - 트랜잭션 readOnly 확인")
+    void testGetAllPremiumUsers_TransactionReadOnly() {
+        // Given
+        List<Subscription> subscriptions = Arrays.asList(subscription1, subscription2);
+
+        when(subscriptionRepository.findByType(SubscriptionType.PREMIUM)).thenReturn(subscriptions);
+        when(adminMapper.toPremiumUserDto(premiumUser1)).thenReturn(premiumUserDTO1);
+        when(adminMapper.toPremiumUserDto(premiumUser2)).thenReturn(premiumUserDTO2);
+
+        // When
+        adminService.getAllPremiumUsers();
+
+        // Then
+        // @Transactional(readOnly = true)가 적용되어 있으므로
+        // 데이터 변경 없이 조회만 수행되는지 확인
+        verify(subscriptionRepository).findByType(SubscriptionType.PREMIUM);
+        verify(subscriptionRepository, never()).save(any(Subscription.class));
+    }
+
+    @Test
+    @DisplayName("모든 프리미엄 사용자 조회 - Stream 처리 확인")
+    void testGetAllPremiumUsers_StreamProcessing() {
+        // Given
+        List<Subscription> subscriptions = Arrays.asList(subscription1, subscription2);
+
+        when(subscriptionRepository.findByType(SubscriptionType.PREMIUM)).thenReturn(subscriptions);
+        when(adminMapper.toPremiumUserDto(premiumUser1)).thenReturn(premiumUserDTO1);
+        when(adminMapper.toPremiumUserDto(premiumUser2)).thenReturn(premiumUserDTO2);
+
+        // When
+        List<PremiumUserDTO> result = adminService.getAllPremiumUsers();
+
+        // Then
+        // Stream 처리가 올바르게 되었는지 확인
+        assertNotNull(result);
+        assertEquals(2, result.size());
+
+        // 모든 subscription에서 user를 가져오고 mapper를 통해 변환되었는지 확인
+        verify(adminMapper, times(2)).toPremiumUserDto(any(User.class));
+    }
+
+    @Test
+    @DisplayName("모든 프리미엄 사용자 조회 - 단일 사용자")
+    void testGetAllPremiumUsers_SingleUser() {
+        // Given
+        List<Subscription> subscriptions = Arrays.asList(subscription1);
+
+        when(subscriptionRepository.findByType(SubscriptionType.PREMIUM)).thenReturn(subscriptions);
+        when(adminMapper.toPremiumUserDto(premiumUser1)).thenReturn(premiumUserDTO1);
+
+        // When
+        List<PremiumUserDTO> result = adminService.getAllPremiumUsers();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        assertEquals("premium1@example.com", result.get(0).getEmail());
+        assertEquals("Premium User 1", result.get(0).getName());
+        assertEquals(subscription1, result.get(0).getSubscription());
+
+        verify(subscriptionRepository).findByType(SubscriptionType.PREMIUM);
+        verify(adminMapper).toPremiumUserDto(premiumUser1);
+    }
+}

--- a/src/test/java/com/jung/planet/common/service/AuthorizationServiceTest.java
+++ b/src/test/java/com/jung/planet/common/service/AuthorizationServiceTest.java
@@ -1,0 +1,160 @@
+package com.jung.planet.common.service;
+
+import com.jung.planet.exception.ResourceNotFoundException;
+import com.jung.planet.plant.entity.Plant;
+import com.jung.planet.plant.repository.PlantRepository;
+import com.jung.planet.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorizationServiceTest {
+
+    @Mock
+    private PlantRepository plantRepository;
+
+    @InjectMocks
+    private AuthorizationService authorizationService;
+
+    private User owner;
+    private User otherUser;
+    private Plant plant;
+
+    @BeforeEach
+    void setUp() {
+        owner = User.builder()
+                .id(1L)
+                .email("owner@example.com")
+                .name("Owner")
+                .build();
+
+        otherUser = User.builder()
+                .id(2L)
+                .email("other@example.com")
+                .name("Other User")
+                .build();
+
+        plant = Plant.builder()
+                .id(1L)
+                .nickName("Test Plant")
+                .user(owner)
+                .build();
+    }
+
+    @Test
+    @DisplayName("식물 소유권 확인 - 소유자인 경우 true 반환")
+    void testIsOwnerOfPlant_Owner_ReturnsTrue() {
+        // Given
+        Long userId = 1L;
+        Long plantId = 1L;
+
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+
+        // When
+        boolean result = authorizationService.isOwnerOfPlant(userId, plantId);
+
+        // Then
+        assertTrue(result);
+        verify(plantRepository).findById(plantId);
+    }
+
+    @Test
+    @DisplayName("식물 소유권 확인 - 소유자가 아닌 경우 false 반환")
+    void testIsOwnerOfPlant_NotOwner_ReturnsFalse() {
+        // Given
+        Long userId = 2L; // otherUser의 ID
+        Long plantId = 1L;
+
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+
+        // When
+        boolean result = authorizationService.isOwnerOfPlant(userId, plantId);
+
+        // Then
+        assertFalse(result);
+        verify(plantRepository).findById(plantId);
+    }
+
+    @Test
+    @DisplayName("식물 소유권 확인 - 식물을 찾을 수 없음")
+    void testIsOwnerOfPlant_PlantNotFound_ThrowsException() {
+        // Given
+        Long userId = 1L;
+        Long plantId = 999L;
+
+        when(plantRepository.findById(plantId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(ResourceNotFoundException.class,
+            () -> authorizationService.isOwnerOfPlant(userId, plantId));
+
+        verify(plantRepository).findById(plantId);
+    }
+
+    @Test
+    @DisplayName("식물 소유권 확인 - 트랜잭션 readOnly 확인")
+    void testIsOwnerOfPlant_TransactionReadOnly() {
+        // Given
+        Long userId = 1L;
+        Long plantId = 1L;
+
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+
+        // When
+        authorizationService.isOwnerOfPlant(userId, plantId);
+
+        // Then
+        // @Transactional(readOnly = true)가 적용되어 있으므로
+        // 데이터 변경 없이 조회만 수행되는지 확인
+        verify(plantRepository).findById(plantId);
+        verify(plantRepository, never()).save(any(Plant.class));
+    }
+
+    @Test
+    @DisplayName("식물 소유권 확인 - null userId")
+    void testIsOwnerOfPlant_NullUserId_ReturnsFalse() {
+        // Given
+        Long userId = null;
+        Long plantId = 1L;
+
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+
+        // When
+        boolean result = authorizationService.isOwnerOfPlant(userId, plantId);
+
+        // Then
+        assertFalse(result);
+        verify(plantRepository).findById(plantId);
+    }
+
+    @Test
+    @DisplayName("식물 소유권 확인 - 중앙화된 권한 검사 로직 테스트")
+    void testIsOwnerOfPlant_CentralizedAuthorizationLogic() {
+        // Given
+        Long userId = 1L;
+        Long plantId = 1L;
+
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+
+        // When
+        boolean result1 = authorizationService.isOwnerOfPlant(userId, plantId);
+        boolean result2 = authorizationService.isOwnerOfPlant(2L, plantId);
+
+        // Then
+        assertTrue(result1);
+        assertFalse(result2);
+
+        // 중앙화된 로직이므로 같은 방식으로 동작하는지 확인
+        verify(plantRepository, times(2)).findById(plantId);
+    }
+}

--- a/src/test/java/com/jung/planet/plant/mapper/PlantMapperTest.java
+++ b/src/test/java/com/jung/planet/plant/mapper/PlantMapperTest.java
@@ -1,0 +1,208 @@
+package com.jung.planet.plant.mapper;
+
+import com.jung.planet.diary.entity.Diary;
+import com.jung.planet.plant.dto.DiaryDetailDTO;
+import com.jung.planet.plant.dto.PlantDetailDTO;
+import com.jung.planet.plant.dto.PlantSummaryDTO;
+import com.jung.planet.plant.entity.Plant;
+import com.jung.planet.user.entity.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PlantMapperTest {
+
+    private PlantMapper plantMapper;
+    private User user;
+    private Plant plant;
+    private Diary diary1;
+    private Diary diary2;
+
+    @BeforeEach
+    void setUp() {
+        plantMapper = new PlantMapper();
+
+        user = User.builder()
+                .id(1L)
+                .email("test@example.com")
+                .name("Test User")
+                .build();
+
+        plant = Plant.builder()
+                .id(1L)
+                .nickName("Test Plant")
+                .scientificName("Plantae Testus")
+                .imgUrl("http://example.com/plant.jpg")
+                .heartCount(10)
+                .createdAt(LocalDateTime.now().minusDays(5))
+                .user(user)
+                .build();
+
+        diary1 = Diary.builder()
+                .id(1L)
+                .content("First diary entry")
+                .imgUrl("http://example.com/diary1.jpg")
+                .isPublic(true)
+                .createdAt(LocalDateTime.now().minusDays(2))
+                .plant(plant)
+                .build();
+
+        diary2 = Diary.builder()
+                .id(2L)
+                .content("Second diary entry")
+                .imgUrl("http://example.com/diary2.jpg")
+                .isPublic(false)
+                .createdAt(LocalDateTime.now().minusDays(1))
+                .plant(plant)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Plant를 PlantSummaryDTO로 변환 - 성공")
+    void testToSummaryDto_Success() {
+        // When
+        PlantSummaryDTO result = plantMapper.toSummaryDto(plant);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(plant.getId(), result.getId());
+        assertEquals(plant.getNickName(), result.getNickName());
+        assertEquals(plant.getHeartCount(), result.getHeartCount());
+        assertEquals(plant.getImgUrl(), result.getImgUrl());
+        assertEquals(5, result.getPeriod()); // 5일 전 생성
+    }
+
+    @Test
+    @DisplayName("Plant를 PlantDetailDTO로 변환 - 좋아요 누르지 않음")
+    void testToDetailDto_NotHearted() {
+        // Given
+        Long userId = 2L; // 다른 사용자
+        boolean isHearted = false;
+
+        // When
+        PlantDetailDTO result = plantMapper.toDetailDto(userId, plant, isHearted);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(plant.getId(), result.getId());
+        assertEquals(plant.getNickName(), result.getNickName());
+        assertEquals(plant.getScientificName(), result.getScientificName());
+        assertEquals(plant.getImgUrl(), result.getImgUrl());
+        assertEquals(plant.getHeartCount(), result.getHeartCount());
+        assertEquals(5, result.getPeriod());
+        assertFalse(result.isHearted());
+        assertFalse(result.isMine()); // userId가 다르므로
+    }
+
+    @Test
+    @DisplayName("Plant를 PlantDetailDTO로 변환 - 좋아요 누름")
+    void testToDetailDto_Hearted() {
+        // Given
+        Long userId = 2L;
+        boolean isHearted = true;
+
+        // When
+        PlantDetailDTO result = plantMapper.toDetailDto(userId, plant, isHearted);
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.isHearted());
+        assertFalse(result.isMine());
+    }
+
+    @Test
+    @DisplayName("Plant를 PlantDetailDTO로 변환 - 자신의 식물")
+    void testToDetailDto_OwnPlant() {
+        // Given
+        Long userId = 1L; // plant owner와 동일
+        boolean isHearted = false;
+
+        // When
+        PlantDetailDTO result = plantMapper.toDetailDto(userId, plant, isHearted);
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.isMine()); // userId가 owner와 동일
+    }
+
+    @Test
+    @DisplayName("Diary를 DiaryDetailDTO로 변환 - 성공")
+    void testToDiaryDetailDto_Success() {
+        // Given
+        Long userId = 1L;
+
+        // When
+        DiaryDetailDTO result = plantMapper.toDiaryDetailDto(diary1, userId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(diary1.getId(), result.getId());
+        assertEquals(diary1.getContent(), result.getContent());
+        assertEquals(diary1.getImgUrl(), result.getImgUrl());
+        assertTrue(result.isPublic());
+        assertTrue(result.isMine()); // userId가 plant owner와 동일
+    }
+
+    @Test
+    @DisplayName("Diary를 DiaryDetailDTO로 변환 - 다른 사용자의 다이어리")
+    void testToDiaryDetailDto_OtherUserDiary() {
+        // Given
+        Long userId = 2L; // 다른 사용자
+
+        // When
+        DiaryDetailDTO result = plantMapper.toDiaryDetailDto(diary1, userId);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(diary1.getId(), result.getId());
+        assertFalse(result.isMine()); // userId가 plant owner와 다름
+    }
+
+    @Test
+    @DisplayName("여러 Plant를 PlantSummaryDTO로 변환")
+    void testToSummaryDto_MultiplePlants() {
+        // Given
+        Plant plant1 = Plant.builder()
+                .id(1L)
+                .nickName("Plant 1")
+                .heartCount(5)
+                .imgUrl("http://example.com/plant1.jpg")
+                .createdAt(LocalDateTime.now().minusDays(10))
+                .user(user)
+                .build();
+
+        Plant plant2 = Plant.builder()
+                .id(2L)
+                .nickName("Plant 2")
+                .heartCount(3)
+                .imgUrl("http://example.com/plant2.jpg")
+                .createdAt(LocalDateTime.now().minusDays(20))
+                .user(user)
+                .build();
+
+        // When
+        PlantSummaryDTO result1 = plantMapper.toSummaryDto(plant1);
+        PlantSummaryDTO result2 = plantMapper.toSummaryDto(plant2);
+
+        // Then
+        assertNotNull(result1);
+        assertNotNull(result2);
+
+        assertEquals("Plant 1", result1.getNickName());
+        assertEquals(5, result1.getHeartCount());
+        assertEquals(10, result1.getPeriod());
+
+        assertEquals("Plant 2", result2.getNickName());
+        assertEquals(3, result2.getHeartCount());
+        assertEquals(20, result2.getPeriod());
+
+        // 각각 독립적인 DTO 객체인지 확인
+        assertNotSame(result1, result2);
+    }
+}

--- a/src/test/java/com/jung/planet/plant/service/UserPlantHeartServiceTest.java
+++ b/src/test/java/com/jung/planet/plant/service/UserPlantHeartServiceTest.java
@@ -1,0 +1,203 @@
+package com.jung.planet.plant.service;
+
+import com.jung.planet.common.service.AuthorizationService;
+import com.jung.planet.exception.UnauthorizedActionException;
+import com.jung.planet.plant.entity.Plant;
+import com.jung.planet.plant.entity.UserPlantHeart;
+import com.jung.planet.plant.entity.UserPlantHeartId;
+import com.jung.planet.plant.repository.PlantRepository;
+import com.jung.planet.plant.repository.UserPlantHeartRepository;
+import com.jung.planet.user.entity.User;
+import com.jung.planet.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserPlantHeartServiceTest {
+
+    @Mock
+    private UserPlantHeartRepository userPlantHeartRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PlantRepository plantRepository;
+
+    @Mock
+    private AuthorizationService authorizationService;
+
+    @InjectMocks
+    private UserPlantHeartService userPlantHeartService;
+
+    private User user;
+    private User plantOwner;
+    private Plant plant;
+    private UserPlantHeartId userPlantHeartId;
+    private UserPlantHeart userPlantHeart;
+
+    @BeforeEach
+    void setUp() {
+        user = User.builder()
+                .id(1L)
+                .email("user@example.com")
+                .name("Test User")
+                .build();
+
+        plantOwner = User.builder()
+                .id(2L)
+                .email("owner@example.com")
+                .name("Plant Owner")
+                .build();
+
+        plant = Plant.builder()
+                .id(1L)
+                .nickName("Test Plant")
+                .heartCount(5)
+                .user(plantOwner)
+                .build();
+
+        userPlantHeartId = new UserPlantHeartId(user.getId(), plant.getId());
+        userPlantHeart = new UserPlantHeart(user, plant);
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 좋아요 추가 성공")
+    void testTogglePlantHeart_AddHeart_Success() {
+        // Given
+        Long userId = 1L;
+        Long plantId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+        when(authorizationService.isOwnerOfPlant(userId, plantId)).thenReturn(false);
+        when(userPlantHeartRepository.findById(userPlantHeartId)).thenReturn(Optional.empty());
+        when(userPlantHeartRepository.save(any(UserPlantHeart.class))).thenReturn(userPlantHeart);
+        when(plantRepository.save(any(Plant.class))).thenReturn(plant);
+
+        // When
+        boolean result = userPlantHeartService.togglePlantHeart(userId, plantId);
+
+        // Then
+        assertTrue(result); // 좋아요가 추가되었으므로 true
+        verify(authorizationService).isOwnerOfPlant(userId, plantId);
+        verify(userPlantHeartRepository).save(any(UserPlantHeart.class));
+        verify(plantRepository).save(plant);
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 좋아요 제거 성공")
+    void testTogglePlantHeart_RemoveHeart_Success() {
+        // Given
+        Long userId = 1L;
+        Long plantId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+        when(authorizationService.isOwnerOfPlant(userId, plantId)).thenReturn(false);
+        when(userPlantHeartRepository.findById(userPlantHeartId)).thenReturn(Optional.of(userPlantHeart));
+        doNothing().when(userPlantHeartRepository).delete(userPlantHeart);
+        when(plantRepository.save(any(Plant.class))).thenReturn(plant);
+
+        // When
+        boolean result = userPlantHeartService.togglePlantHeart(userId, plantId);
+
+        // Then
+        assertFalse(result); // 좋아요가 제거되었으므로 false
+        verify(authorizationService).isOwnerOfPlant(userId, plantId);
+        verify(userPlantHeartRepository).delete(userPlantHeart);
+        verify(plantRepository).save(plant);
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 자신의 식물에 좋아요 시도 (실패)")
+    void testTogglePlantHeart_OwnPlant_ThrowsException() {
+        // Given
+        Long userId = 2L; // plantOwner의 ID
+        Long plantId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(plantOwner));
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+        when(authorizationService.isOwnerOfPlant(userId, plantId)).thenReturn(true);
+
+        // When & Then
+        assertThrows(UnauthorizedActionException.class,
+            () -> userPlantHeartService.togglePlantHeart(userId, plantId));
+
+        verify(authorizationService).isOwnerOfPlant(userId, plantId);
+        verify(userPlantHeartRepository, never()).save(any(UserPlantHeart.class));
+        verify(userPlantHeartRepository, never()).delete(any(UserPlantHeart.class));
+        verify(plantRepository, never()).save(any(Plant.class));
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 사용자를 찾을 수 없음")
+    void testTogglePlantHeart_UserNotFound() {
+        // Given
+        Long userId = 999L;
+        Long plantId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(EntityNotFoundException.class,
+            () -> userPlantHeartService.togglePlantHeart(userId, plantId));
+
+        verify(userRepository).findById(userId);
+        verify(plantRepository, never()).findById(anyLong());
+        verify(authorizationService, never()).isOwnerOfPlant(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - 식물을 찾을 수 없음")
+    void testTogglePlantHeart_PlantNotFound() {
+        // Given
+        Long userId = 1L;
+        Long plantId = 999L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(plantRepository.findById(plantId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(EntityNotFoundException.class,
+            () -> userPlantHeartService.togglePlantHeart(userId, plantId));
+
+        verify(userRepository).findById(userId);
+        verify(plantRepository).findById(plantId);
+        verify(authorizationService, never()).isOwnerOfPlant(anyLong(), anyLong());
+    }
+
+    @Test
+    @DisplayName("좋아요 토글 - AuthorizationService 통합 확인")
+    void testTogglePlantHeart_UsesAuthorizationService() {
+        // Given
+        Long userId = 1L;
+        Long plantId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+        when(authorizationService.isOwnerOfPlant(userId, plantId)).thenReturn(false);
+        when(userPlantHeartRepository.findById(userPlantHeartId)).thenReturn(Optional.empty());
+        when(userPlantHeartRepository.save(any(UserPlantHeart.class))).thenReturn(userPlantHeart);
+        when(plantRepository.save(any(Plant.class))).thenReturn(plant);
+
+        // When
+        userPlantHeartService.togglePlantHeart(userId, plantId);
+
+        // Then
+        // AuthorizationService가 호출되었는지 확인 (중복 권한 검사 로직 제거 확인)
+        verify(authorizationService, times(1)).isOwnerOfPlant(userId, plantId);
+    }
+}

--- a/src/test/java/com/jung/planet/report/service/ReportServiceTest.java
+++ b/src/test/java/com/jung/planet/report/service/ReportServiceTest.java
@@ -189,7 +189,7 @@ class ReportServiceTest {
         List<Report> reports = Arrays.asList(diaryReport);
         DiaryDetailDTO diaryDetailDTO = new DiaryDetailDTO();
 
-        when(reportRepository.findAllDiaryReportsWithUser()).thenReturn(reports);
+        when(reportRepository.findDiaryReportsWithUserFetchJoin()).thenReturn(reports);
         when(diaryService.findDiary(anyLong(), anyLong())).thenReturn(diaryDetailDTO);
         when(userRepository.findById(2L)).thenReturn(Optional.of(reporter));
 
@@ -199,7 +199,7 @@ class ReportServiceTest {
         // Then
         assertNotNull(result);
         assertEquals(1, result.size());
-        verify(reportRepository).findAllDiaryReportsWithUser(); // fetch join 쿼리 사용 확인
+        verify(reportRepository).findDiaryReportsWithUserFetchJoin(); // fetch join 쿼리 사용 확인
         verify(diaryService).findDiary(anyLong(), anyLong());
         verify(userRepository).findById(2L);
     }
@@ -211,7 +211,7 @@ class ReportServiceTest {
         List<Report> reports = Arrays.asList(plantReport);
         PlantDetailDTO plantDetailDTO = new PlantDetailDTO();
 
-        when(reportRepository.findAllPlantReportsWithUser()).thenReturn(reports);
+        when(reportRepository.findPlantReportsWithUserFetchJoin()).thenReturn(reports);
         when(plantService.getPlantDetailsByPlantId(anyLong(), anyLong())).thenReturn(plantDetailDTO);
         when(userRepository.findById(2L)).thenReturn(Optional.of(reporter));
 
@@ -221,7 +221,7 @@ class ReportServiceTest {
         // Then
         assertNotNull(result);
         assertEquals(1, result.size());
-        verify(reportRepository).findAllPlantReportsWithUser(); // fetch join 쿼리 사용 확인
+        verify(reportRepository).findPlantReportsWithUserFetchJoin(); // fetch join 쿼리 사용 확인
         verify(plantService).getPlantDetailsByPlantId(anyLong(), anyLong());
         verify(userRepository).findById(2L);
     }
@@ -232,13 +232,13 @@ class ReportServiceTest {
         // Given
         List<Report> reports = Arrays.asList(diaryReport);
 
-        when(reportRepository.findAllDiaryReportsWithUser()).thenReturn(reports);
+        when(reportRepository.findDiaryReportsWithUserFetchJoin()).thenReturn(reports);
         when(userRepository.findById(2L)).thenReturn(Optional.empty());
 
         // When & Then
         assertThrows(EntityNotFoundException.class, () -> reportService.getAllDiaryReports());
 
-        verify(reportRepository).findAllDiaryReportsWithUser();
+        verify(reportRepository).findDiaryReportsWithUserFetchJoin();
         verify(userRepository).findById(2L);
     }
 
@@ -248,13 +248,13 @@ class ReportServiceTest {
         // Given
         List<Report> reports = Arrays.asList(plantReport);
 
-        when(reportRepository.findAllPlantReportsWithUser()).thenReturn(reports);
+        when(reportRepository.findPlantReportsWithUserFetchJoin()).thenReturn(reports);
         when(userRepository.findById(2L)).thenReturn(Optional.empty());
 
         // When & Then
         assertThrows(EntityNotFoundException.class, () -> reportService.getAllPlantReports());
 
-        verify(reportRepository).findAllPlantReportsWithUser();
+        verify(reportRepository).findPlantReportsWithUserFetchJoin();
         verify(userRepository).findById(2L);
     }
 }

--- a/src/test/java/com/jung/planet/report/service/ReportServiceTest.java
+++ b/src/test/java/com/jung/planet/report/service/ReportServiceTest.java
@@ -1,0 +1,260 @@
+package com.jung.planet.report.service;
+
+import com.jung.planet.admin.service.SlackNotificationService;
+import com.jung.planet.diary.dto.DiaryDetailDTO;
+import com.jung.planet.diary.entity.Diary;
+import com.jung.planet.diary.repository.DiaryRepository;
+import com.jung.planet.diary.service.DiaryService;
+import com.jung.planet.plant.dto.PlantDetailDTO;
+import com.jung.planet.plant.entity.Plant;
+import com.jung.planet.plant.repository.PlantRepository;
+import com.jung.planet.plant.service.PlantService;
+import com.jung.planet.report.dto.ReportDTO;
+import com.jung.planet.report.entity.Report;
+import com.jung.planet.report.entity.ReportType;
+import com.jung.planet.report.repository.ReportRepository;
+import com.jung.planet.user.entity.User;
+import com.jung.planet.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReportServiceTest {
+
+    @Mock
+    private ReportRepository reportRepository;
+
+    @Mock
+    private PlantRepository plantRepository;
+
+    @Mock
+    private DiaryRepository diaryRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PlantService plantService;
+
+    @Mock
+    private DiaryService diaryService;
+
+    @Mock
+    private SlackNotificationService slackNotificationService;
+
+    @InjectMocks
+    private ReportService reportService;
+
+    private Plant plant;
+    private Diary diary;
+    private User reporter;
+    private User plantOwner;
+    private Report plantReport;
+    private Report diaryReport;
+
+    @BeforeEach
+    void setUp() {
+        // Setup test data
+        plantOwner = User.builder()
+                .id(1L)
+                .email("owner@example.com")
+                .name("Plant Owner")
+                .build();
+
+        reporter = User.builder()
+                .id(2L)
+                .email("reporter@example.com")
+                .name("Reporter")
+                .build();
+
+        plant = Plant.builder()
+                .id(1L)
+                .nickName("Test Plant")
+                .imgUrl("http://example.com/plant.jpg")
+                .user(plantOwner)
+                .build();
+
+        diary = Diary.builder()
+                .id(1L)
+                .content("Test Diary Content")
+                .imgUrl("http://example.com/diary.jpg")
+                .plant(plant)
+                .build();
+
+        plantReport = new Report();
+        plantReport.setId(1L);
+        plantReport.setReportedPlant(plant);
+        plantReport.setReporterId(2L);
+
+        diaryReport = new Report();
+        diaryReport.setId(2L);
+        diaryReport.setReportedDiary(diary);
+        diaryReport.setReporterId(2L);
+    }
+
+    @Test
+    @DisplayName("식물 신고 - 성공")
+    void testReportEntity_Plant_Success() {
+        // Given
+        Long plantId = 1L;
+        Long reporterId = 2L;
+
+        when(plantRepository.findById(plantId)).thenReturn(Optional.of(plant));
+        when(reportRepository.save(any(Report.class))).thenReturn(plantReport);
+        doNothing().when(slackNotificationService).sendSlackReportNotification(anyString(), anyMap());
+
+        // When
+        reportService.reportEntity(plantId, ReportType.PLANT, reporterId);
+
+        // Then
+        verify(plantRepository).findById(plantId);
+        verify(reportRepository).save(any(Report.class));
+        verify(slackNotificationService).sendSlackReportNotification(eq("식물 신고"), anyMap());
+    }
+
+    @Test
+    @DisplayName("식물 신고 - 식물을 찾을 수 없음")
+    void testReportEntity_Plant_NotFound() {
+        // Given
+        Long plantId = 999L;
+        Long reporterId = 2L;
+
+        when(plantRepository.findById(plantId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(EntityNotFoundException.class,
+            () -> reportService.reportEntity(plantId, ReportType.PLANT, reporterId));
+
+        verify(plantRepository).findById(plantId);
+        verify(reportRepository, never()).save(any(Report.class));
+        verify(slackNotificationService, never()).sendSlackReportNotification(anyString(), anyMap());
+    }
+
+    @Test
+    @DisplayName("다이어리 신고 - 성공")
+    void testReportEntity_Diary_Success() {
+        // Given
+        Long diaryId = 1L;
+        Long reporterId = 2L;
+
+        when(diaryRepository.findById(diaryId)).thenReturn(Optional.of(diary));
+        when(reportRepository.save(any(Report.class))).thenReturn(diaryReport);
+        doNothing().when(slackNotificationService).sendSlackReportNotification(anyString(), anyMap());
+
+        // When
+        reportService.reportEntity(diaryId, ReportType.DIARY, reporterId);
+
+        // Then
+        verify(diaryRepository).findById(diaryId);
+        verify(reportRepository).save(any(Report.class));
+        verify(slackNotificationService).sendSlackReportNotification(eq("다이어리 신고"), anyMap());
+    }
+
+    @Test
+    @DisplayName("다이어리 신고 - 다이어리를 찾을 수 없음")
+    void testReportEntity_Diary_NotFound() {
+        // Given
+        Long diaryId = 999L;
+        Long reporterId = 2L;
+
+        when(diaryRepository.findById(diaryId)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(EntityNotFoundException.class,
+            () -> reportService.reportEntity(diaryId, ReportType.DIARY, reporterId));
+
+        verify(diaryRepository).findById(diaryId);
+        verify(reportRepository, never()).save(any(Report.class));
+        verify(slackNotificationService, never()).sendSlackReportNotification(anyString(), anyMap());
+    }
+
+    @Test
+    @DisplayName("모든 다이어리 신고 조회 - fetch join으로 N+1 문제 해결")
+    void testGetAllDiaryReports_WithFetchJoin() {
+        // Given
+        List<Report> reports = Arrays.asList(diaryReport);
+        DiaryDetailDTO diaryDetailDTO = new DiaryDetailDTO();
+
+        when(reportRepository.findAllDiaryReportsWithUser()).thenReturn(reports);
+        when(diaryService.findDiary(anyLong(), anyLong())).thenReturn(diaryDetailDTO);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(reporter));
+
+        // When
+        List<ReportDTO> result = reportService.getAllDiaryReports();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        verify(reportRepository).findAllDiaryReportsWithUser(); // fetch join 쿼리 사용 확인
+        verify(diaryService).findDiary(anyLong(), anyLong());
+        verify(userRepository).findById(2L);
+    }
+
+    @Test
+    @DisplayName("모든 식물 신고 조회 - fetch join으로 N+1 문제 해결")
+    void testGetAllPlantReports_WithFetchJoin() {
+        // Given
+        List<Report> reports = Arrays.asList(plantReport);
+        PlantDetailDTO plantDetailDTO = new PlantDetailDTO();
+
+        when(reportRepository.findAllPlantReportsWithUser()).thenReturn(reports);
+        when(plantService.getPlantDetailsByPlantId(anyLong(), anyLong())).thenReturn(plantDetailDTO);
+        when(userRepository.findById(2L)).thenReturn(Optional.of(reporter));
+
+        // When
+        List<ReportDTO> result = reportService.getAllPlantReports();
+
+        // Then
+        assertNotNull(result);
+        assertEquals(1, result.size());
+        verify(reportRepository).findAllPlantReportsWithUser(); // fetch join 쿼리 사용 확인
+        verify(plantService).getPlantDetailsByPlantId(anyLong(), anyLong());
+        verify(userRepository).findById(2L);
+    }
+
+    @Test
+    @DisplayName("다이어리 신고 조회 - 신고자를 찾을 수 없음")
+    void testGetAllDiaryReports_ReporterNotFound() {
+        // Given
+        List<Report> reports = Arrays.asList(diaryReport);
+
+        when(reportRepository.findAllDiaryReportsWithUser()).thenReturn(reports);
+        when(userRepository.findById(2L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(EntityNotFoundException.class, () -> reportService.getAllDiaryReports());
+
+        verify(reportRepository).findAllDiaryReportsWithUser();
+        verify(userRepository).findById(2L);
+    }
+
+    @Test
+    @DisplayName("식물 신고 조회 - 신고자를 찾을 수 없음")
+    void testGetAllPlantReports_ReporterNotFound() {
+        // Given
+        List<Report> reports = Arrays.asList(plantReport);
+
+        when(reportRepository.findAllPlantReportsWithUser()).thenReturn(reports);
+        when(userRepository.findById(2L)).thenReturn(Optional.empty());
+
+        // When & Then
+        assertThrows(EntityNotFoundException.class, () -> reportService.getAllPlantReports());
+
+        verify(reportRepository).findAllPlantReportsWithUser();
+        verify(userRepository).findById(2L);
+    }
+}


### PR DESCRIPTION
1. 레이어 분리 개선
   - UserController의 Repository 직접 접근 제거
   - UserPlantHeartRepository, UserRepository 의존성 제거
   - 비즈니스 로직을 Service로 이동 (refreshTokens, getMyInfo)
   - 중복 로거 선언 제거 (@Slf4j로 통일)

2. 예외 처리 일관성 확보
   - CloudflareR2Uploader의 RuntimeException을 ExternalServiceException으로 변경
   - 예외 발생 시 상세한 로깅 추가
   - PlantController의 불필요한 try-catch 제거 (GlobalExceptionHandler에 위임)

3. 코드 품질 개선
   - UserService에 refreshUserTokens, getUserInfo 메서드 추가
   - JavaDoc 주석 추가로 가독성 향상
   - 트랜잭션 어노테이션 적절히 적용 (readOnly)